### PR TITLE
Add super randomizer control panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,109 +1,230 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Web 808 Drum Machine</title>
-  <link rel="stylesheet" href="styles.css">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>8Beat Chiptune Studio</title>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-<div class="app">
-    <!-- Header -->
+  <div class="app">
     <header class="header">
-      <div class="header-title">
-        <div class="header-logo"></div>
-        <div class="header-text">
-          <h1>Web 808 Drum Machine</h1>
-          <div class="subtitle">Professional drum machine with 25 presets, effects, and recording</div>
-      </div>
-    </div>
-      
-    <div class="transport">
-      <button class="btn primary" id="play">Play</button>
-      <button class="btn" id="stop">Stop</button>
-        <button class="btn" id="recordBtn">Record</button>
-        <button class="btn" id="downloadBtn">Download</button>
-        <span id="recordTime" class="text-accent"></span>
-        
-        <div class="control-group">
-          <label>Tempo</label>
-        <input id="bpm" type="range" min="40" max="220" value="120" />
-          <span class="value-display" id="bpmVal">120</span>
-      </div>
-        
-        <div class="control-group">
-          <label>Steps</label>
-        <select id="steps">
-          <option>8</option>
-          <option selected>16</option>
-          <option>32</option>
-        </select>
-      </div>
-        
-        <div class="control-group">
-          <label>Step</label>
-          <span class="value-display" id="stepCounter">0</span>
+      <div class="hero">
+        <span class="hero-badge">Chiptune Studio</span>
+        <h1>8Beat Chiptune Studio</h1>
+        <p class="hero-copy">Design full retro game soundtracks with layered pulse leads, crunchy drums, and instant chip FX.</p>
+        <div class="hero-tags">
+          <span>Arpeggiator</span>
+          <span>Chip FX</span>
+          <span>Multi-track</span>
+          <span>Live Pads</span>
         </div>
-    </div>
-  </header>
+      </div>
+      <div class="transport">
+        <div class="transport-main">
+          <button class="btn primary" id="play">Play</button>
+          <button class="btn" id="stop">Stop</button>
+          <button class="btn" id="recordBtn">Record</button>
+          <button class="btn" id="downloadBtn">Download</button>
+          <span id="recordTime" class="transport-time"></span>
+        </div>
+        <div class="transport-controls">
+          <div class="control-group inline">
+            <label for="bpm">Tempo</label>
+            <input id="bpm" type="range" min="40" max="220" value="120" />
+            <span class="value-display" id="bpmVal">120</span>
+          </div>
+          <div class="control-group inline">
+            <label for="steps">Steps</label>
+            <select id="steps">
+              <option value="8">8</option>
+              <option value="16" selected>16</option>
+              <option value="32">32</option>
+            </select>
+          </div>
+        </div>
+      </div>
 
-    <!-- Pads Section -->
-    <section class="pads-section">
-      <div class="pads-grid"></div>
+      <div class="super-randomizer" id="superRandomizer">
+        <div class="super-randomizer-header">
+          <div class="super-randomizer-copy">
+            <h2>Super Randomizer</h2>
+            <p>Automate fresh chip jams by shuffling your studio on a timer.</p>
+          </div>
+          <button class="btn primary" id="superRandomToggle" aria-pressed="false">Start Chaos</button>
+        </div>
+        <div class="super-randomizer-options">
+          <label class="super-randomizer-option">
+            <input type="checkbox" id="superRandomTracks" data-feature="tracks" checked />
+            <span>Tracks</span>
+          </label>
+          <label class="super-randomizer-option">
+            <input type="checkbox" id="superRandomInstruments" data-feature="instruments" checked />
+            <span>Instruments</span>
+          </label>
+          <label class="super-randomizer-option">
+            <input type="checkbox" id="superRandomKey" data-feature="key" checked />
+            <span>Key &amp; Scale</span>
+          </label>
+          <label class="super-randomizer-option">
+            <input type="checkbox" id="superRandomTempo" data-feature="tempo" checked />
+            <span>Tempo</span>
+          </label>
+          <label class="super-randomizer-option">
+            <input type="checkbox" id="superRandomIntervalToggle" data-feature="interval" checked />
+            <span>Interval</span>
+          </label>
+        </div>
+        <div class="super-randomizer-controls">
+          <div class="control-group inline super-randomizer-interval">
+            <label for="superRandomInterval">Base Interval</label>
+            <input id="superRandomInterval" type="range" min="2" max="20" step="1" value="8" />
+            <span class="value-display" id="superRandomIntervalVal">8s</span>
+          </div>
+          <div class="super-randomizer-status">
+            <span class="label">Next shuffle</span>
+            <span class="value-display" id="superRandomCountdown">--</span>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <section class="studio">
+      <aside class="sidebar">
+        <div class="panel scale-panel">
+          <div class="panel-header">
+            <h2>Scale &amp; Key</h2>
+            <p>Harmonic context for melodic lanes</p>
+          </div>
+          <div class="panel-body stack">
+            <div class="control-group">
+              <label for="scaleRoot">Root</label>
+              <select id="scaleRoot">
+                <option>C</option>
+                <option>C#</option>
+                <option>D</option>
+                <option>D#</option>
+                <option>E</option>
+                <option>F</option>
+                <option>F#</option>
+                <option>G</option>
+                <option>G#</option>
+                <option>A</option>
+                <option>A#</option>
+                <option>B</option>
+              </select>
+            </div>
+            <div class="control-group">
+              <label for="scaleMode">Mode</label>
+              <select id="scaleMode">
+                <option value="minor" selected>Minor</option>
+                <option value="major">Major</option>
+                <option value="dorian">Dorian</option>
+                <option value="mixolydian">Mixolydian</option>
+                <option value="lydian">Lydian</option>
+                <option value="phrygian">Phrygian</option>
+                <option value="harmonic">Harmonic Minor</option>
+                <option value="pentatonic">Pentatonic</option>
+                <option value="chip">Chip Special</option>
+              </select>
+            </div>
+            <button class="btn ghost" id="randomizeScaleBtn">Random Scale</button>
+            <div class="scale-preview" id="scalePreview"></div>
+          </div>
+        </div>
+
+        <div class="panel soundboard-panel">
+          <div class="panel-header">
+            <h2>Soundboard</h2>
+            <p>Trigger instant FX</p>
+          </div>
+          <div class="soundboard-grid" id="soundboard"></div>
+        </div>
+
+        <div class="panel utility-panel">
+          <div class="panel-header">
+            <h2>Pattern Tools</h2>
+          </div>
+          <div class="panel-body stack">
+            <button class="btn outline" id="randomizeBtn">Randomize Jam</button>
+            <button class="btn outline" id="clearBtn">Clear All</button>
+            <button class="btn outline" id="loadSampleBtn">Load Sample</button>
+            <input id="loadSampleFile" type="file" accept="audio/*" hidden />
+          </div>
+        </div>
+      </aside>
+
+      <main class="workspace">
+        <div class="sequencer-toolbar">
+          <div class="toolbar-left">
+            <button class="btn ghost" id="addTrackBtn">Add Track</button>
+            <div class="control-group inline">
+              <label for="swing">Swing</label>
+              <input id="swing" type="range" min="0" max="0.6" step="0.01" value="0" />
+              <span class="value-display" id="swingVal">0%</span>
+            </div>
+          </div>
+          <div class="toolbar-right">
+            <div class="control-group inline">
+              <label for="drive">Drive</label>
+              <input id="drive" type="range" min="0" max="1" step="0.01" value="0.25" />
+              <span class="value-display" id="driveVal">0.25</span>
+            </div>
+            <div class="control-group inline">
+              <label for="delayMix">Delay</label>
+              <input id="delayMix" type="range" min="0" max="1" step="0.01" value="0.15" />
+              <span class="value-display" id="delayVal">0.15</span>
+            </div>
+          </div>
+        </div>
+
+        <section class="tracks-section" id="rack"></section>
+
+        <section class="pads-section">
+          <div class="section-header">
+            <h2>Performance Pads</h2>
+            <p>Tap to audition instruments. Shift-click steps to cycle velocity.</p>
+          </div>
+          <div class="pads-grid"></div>
+        </section>
+      </main>
     </section>
 
-    <!-- Tracks Section -->
-    <section class="tracks-section" id="rack"></section>
-
-    <!-- Footer -->
     <footer class="footer">
-      <div class="presets-container" id="presets">
-        <span class="text-muted">Presets:</span>
-        <button class="preset-chip" data-preset="chiptune">Chiptune</button>
-        <button class="preset-chip" data-preset="electro">Electro</button>
-        <button class="preset-chip" data-preset="random">Random</button>
-        <button class="preset-chip" data-preset="clear">Clear</button>
-    </div>
-      
-      <div class="footer-controls">
-        <div class="control-group">
-          <label>Swing</label>
-      <input id="swing" type="range" min="0" max="0.6" step="0.01" value="0" />
-          <span class="value-display" id="swingVal">0%</span>
-    </div>
-        
-        <div class="control-group">
-          <label>Drive</label>
-          <input id="drive" type="range" min="0" max="1" step="0.01" value="0.2" />
-          <span class="value-display" id="driveVal">0.20</span>
-</div>
-
-        <div class="control-group">
-          <label>Delay</label>
-          <input id="delayMix" type="range" min="0" max="1" step="0.01" value="0.15" />
-          <span class="value-display" id="delayVal">0.15</span>
+      <div class="footer-info">
+        <h3>Workflow Tips</h3>
+        <p>Use multiple melodic tracks with different waveforms for leads, bass, and harmonies. Right-click a cell to soften or remove notes and combine with swing for groovy chip rhythms.</p>
+      </div>
+      <div class="footer-meta">
+        <div class="stat">
+          <span class="label">Current Step</span>
+          <span class="value-display" id="stepCounter">0</span>
+        </div>
+        <div class="stat">
+          <span class="label">Scale</span>
+          <span class="value-display" id="scaleSummary">C minor</span>
         </div>
       </div>
-      
-      <div class="manual-buttons">
-        <div class="button-group">
-          <label class="button-label">Sample Loading</label>
-          <button class="btn manual-btn" id="loadSampleBtn">Load Sample</button>
-          <input id="loadSampleFile" type="file" accept="audio/*" style="display:none" />
-        </div>
-    </div>
     </footer>
-    </div>
+  </div>
 
-  <!-- Scripts -->
+  <div class="instrument-overlay" id="instrumentOverlay">
+    <div class="overlay-content">
+      <div class="overlay-header">
+        <h2>Select an instrument</h2>
+        <button class="btn ghost" id="closeOverlayBtn">Close</button>
+      </div>
+      <div class="instrument-grid" id="instrumentGrid"></div>
+    </div>
+  </div>
+
   <script src="app.js"></script>
   <script src="ui.js"></script>
   <script src="sequencer.js"></script>
   <script>
-    // Initialize the app when DOM is ready
     document.addEventListener('DOMContentLoaded', () => {
       initApp();
-});
-</script>
+    });
+  </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,820 +1,944 @@
-/* Modern Web 808 Drum Machine - CSS */
+/* 8Beat Chiptune Studio - Visual Design */
 
 :root {
-  /* Color System */
-  --bg-primary: #0a0a0f;
-  --bg-secondary: #111118;
-  --bg-tertiary: #1a1a24;
-  --bg-elevated: #252530;
-  --bg-hover: #2a2a38;
-  
-  --text-primary: #ffffff;
-  --text-secondary: #b8b8c8;
-  --text-muted: #8a8a9a;
-  --text-accent: #00ff88;
-  
-  --accent-primary: #00ff88;
-  --accent-secondary: #00ccff;
-  --accent-tertiary: #ff6b9d;
-  --accent-warning: #ffaa00;
-  --accent-danger: #ff4757;
-  
-  --border-primary: #333340;
-  --border-secondary: #444450;
-  --border-accent: #00ff88;
-  
-  /* Shadows */
-  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.3);
-  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.4);
-  --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-  --shadow-glow: 0 0 20px rgba(0, 255, 136, 0.3);
-  
-  /* Spacing */
-  --space-xs: 4px;
-  --space-sm: 8px;
-  --space-md: 16px;
-  --space-lg: 24px;
-  --space-xl: 32px;
-  
-  /* Border Radius */
-  --radius-sm: 6px;
-  --radius-md: 12px;
-  --radius-lg: 16px;
-  --radius-xl: 24px;
-  
-  /* Typography */
-  --font-mono: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
-  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --bg-main: #06060b;
+  --bg-secondary: #0f0f18;
+  --bg-tertiary: #171724;
+  --surface: rgba(18, 18, 32, 0.92);
+  --surface-strong: rgba(28, 28, 44, 0.95);
+  --surface-glow: rgba(32, 32, 48, 0.75);
+  --border: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(0, 255, 200, 0.4);
+  --text-primary: #f7f7fb;
+  --text-secondary: #b8b8d4;
+  --text-muted: #7a7a92;
+  --accent-primary: #00ffb0;
+  --accent-secondary: #00c0ff;
+  --accent-tertiary: #ff75c3;
+  --accent-warning: #ffba4a;
+  --accent-danger: #ff5468;
+  --shadow-soft: 0 12px 40px rgba(0, 0, 0, 0.35);
+  --shadow-glow: 0 0 24px rgba(0, 255, 176, 0.25);
+  --radius-sm: 8px;
+  --radius-md: 16px;
+  --radius-lg: 22px;
+  --space-xs: 6px;
+  --space-sm: 12px;
+  --space-md: 20px;
+  --space-lg: 32px;
+  --space-xl: 48px;
+  --font-sans: 'Inter', 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
 }
 
-/* Reset & Base */
-* {
+*, *::before, *::after {
   box-sizing: border-box;
-  margin: 0;
-  padding: 0;
 }
 
 html, body {
-  height: 100%;
-  background: linear-gradient(135deg, var(--bg-primary) 0%, var(--bg-secondary) 50%, var(--bg-tertiary) 100%);
+  margin: 0;
+  min-height: 100%;
+  background: radial-gradient(circle at top, rgba(0, 255, 176, 0.08), transparent 55%),
+              radial-gradient(circle at bottom right, rgba(255, 120, 200, 0.08), transparent 45%),
+              linear-gradient(140deg, var(--bg-main), var(--bg-tertiary));
   color: var(--text-primary);
   font-family: var(--font-sans);
-  font-size: 14px;
-  line-height: 1.5;
-  overflow-x: hidden;
+  font-size: 15px;
+  line-height: 1.6;
 }
 
-/* Scrollbar */
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-
-::-webkit-scrollbar-track {
-  background: var(--bg-secondary);
-}
-
-::-webkit-scrollbar-thumb {
-  background: var(--border-primary);
-  border-radius: var(--radius-sm);
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: var(--border-secondary);
-}
-
-/* App Container */
-.app {
-  display: grid;
-  grid-template-rows: auto auto 1fr auto;
-  gap: var(--space-lg);
-  max-width: 1400px;
-  margin: 0 auto;
-  padding: var(--space-lg);
-  min-height: 100vh;
-}
-
-/* Header */
-.header {
-  background: linear-gradient(135deg, rgba(255,255,255,0.05) 0%, rgba(255,255,255,0.02) 100%);
-  backdrop-filter: blur(20px);
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-lg);
-  padding: var(--space-lg);
+body {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-lg);
-  box-shadow: var(--shadow-md);
-}
-
-.header-title {
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
-}
-
-.header-logo {
-  width: 48px;
-  height: 48px;
-  background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
-  border-radius: var(--radius-md);
-  position: relative;
-  overflow: hidden;
-  box-shadow: var(--shadow-glow);
-  animation: logoGlow 3s ease-in-out infinite alternate;
-}
-
-.header-logo::before {
-  content: '';
-  position: absolute;
-  inset: 2px;
-  background: linear-gradient(45deg, transparent 30%, rgba(255,255,255,0.1) 50%, transparent 70%);
-  border-radius: calc(var(--radius-md) - 2px);
-}
-
-.header-logo::after {
-  content: '808';
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
   justify-content: center;
-  font-family: var(--font-mono);
-  font-weight: 700;
-  font-size: 12px;
-  color: var(--text-primary);
-  text-shadow: 0 0 10px rgba(0,0,0,0.5);
 }
 
-@keyframes logoGlow {
-  0% { box-shadow: var(--shadow-glow); }
-  100% { box-shadow: 0 0 30px rgba(0, 255, 136, 0.5); }
+a {
+  color: inherit;
 }
 
-.header-text h1 {
-  font-size: 24px;
+.app {
+  width: min(1200px, 94vw);
+  padding: var(--space-lg);
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: var(--space-lg);
+}
+
+.header {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(0, 0, 0, 0.35));
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: var(--space-lg);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-lg);
+  align-items: stretch;
+  box-shadow: var(--shadow-soft);
+}
+
+.hero {
+  flex: 1 1 320px;
+}
+
+.hero-badge {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: linear-gradient(120deg, rgba(0, 255, 176, 0.25), rgba(0, 192, 255, 0.25));
+  color: var(--accent-primary);
+  font-weight: 600;
+  letter-spacing: 0.4px;
+}
+
+.hero h1 {
+  margin: 12px 0 10px;
+  font-size: clamp(2.2rem, 4vw, 2.9rem);
   font-weight: 700;
-  margin-bottom: var(--space-xs);
-  background: linear-gradient(135deg, var(--text-primary), var(--accent-primary));
+  background: linear-gradient(120deg, #ffffff, var(--accent-primary));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
-  background-clip: text;
 }
 
-.header-text .subtitle {
+.hero-copy {
   color: var(--text-secondary);
-  font-size: 13px;
+  max-width: 520px;
+  margin: 0 0 var(--space-sm);
 }
 
-/* Transport Controls */
+.hero-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.hero-tags span {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.7px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-secondary);
+}
+
 .transport {
+  flex: 1 1 280px;
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: var(--space-md);
+  justify-content: space-between;
 }
 
-.btn {
-  background: linear-gradient(135deg, var(--bg-elevated) 0%, var(--bg-tertiary) 100%);
-  color: var(--text-primary);
-  border: 1px solid var(--border-primary);
-  padding: var(--space-sm) var(--space-md);
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  transition: all 0.2s ease;
-  font-family: var(--font-mono);
-  font-size: 12px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  box-shadow: var(--shadow-sm);
-  user-select: none;
-  position: relative;
-  overflow: hidden;
-}
-
-.btn::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.1), transparent);
-  transition: left 0.5s ease;
-}
-
-.btn:hover::before {
-  left: 100%;
-}
-
-.btn:hover {
-  background: linear-gradient(135deg, var(--bg-hover) 0%, var(--bg-elevated) 100%);
-  border-color: var(--border-secondary);
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-md);
-}
-
-.btn:active {
-  transform: translateY(0);
-  box-shadow: var(--shadow-sm);
-}
-
-.btn.primary {
-  background: linear-gradient(135deg, var(--accent-primary) 0%, #00cc6a 100%);
-  border-color: var(--accent-primary);
-  color: var(--bg-primary);
-  box-shadow: 0 0 20px rgba(0, 255, 136, 0.3);
-}
-
-.btn.primary:hover {
-  background: linear-gradient(135deg, #00ff99 0%, var(--accent-primary) 100%);
-  box-shadow: 0 0 30px rgba(0, 255, 136, 0.5);
-}
-
-.btn.danger {
-  background: linear-gradient(135deg, var(--accent-danger) 0%, #ff3742 100%);
-  border-color: var(--accent-danger);
-  color: var(--text-primary);
-}
-
-.btn.danger:hover {
-  background: linear-gradient(135deg, #ff5a6b 0%, var(--accent-danger) 100%);
-}
-
-.btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  transform: none;
-}
-
-/* Control Groups */
-.control-group {
+.transport-main {
   display: flex;
-  align-items: center;
+  flex-wrap: wrap;
   gap: var(--space-sm);
-  background: linear-gradient(135deg, rgba(255,255,255,0.03) 0%, rgba(255,255,255,0.01) 100%);
-  border: 1px solid var(--border-primary);
+  align-items: center;
+}
+
+.transport-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.transport-time {
+  font-family: var(--font-mono);
+  color: var(--accent-tertiary);
+  min-width: 54px;
+}
+
+.super-randomizer {
+  flex: 1 1 320px;
+  min-width: 260px;
+  padding: var(--space-md);
   border-radius: var(--radius-md);
-  padding: var(--space-sm) var(--space-md);
-  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(12, 12, 28, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.control-group label {
-  color: var(--text-secondary);
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
+.super-randomizer.running {
+  border-color: rgba(0, 255, 176, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(0, 255, 176, 0.25), 0 10px 28px rgba(0, 255, 176, 0.15);
+}
+
+.super-randomizer-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.super-randomizer-copy h2 {
+  margin: 0 0 6px;
+  font-size: 1.15rem;
   letter-spacing: 0.5px;
-  min-width: 60px;
 }
 
-.control-group input[type="range"] {
-  width: 120px;
-  height: 4px;
-  background: var(--bg-tertiary);
-  border-radius: 2px;
-  outline: none;
-  -webkit-appearance: none;
+.super-randomizer-copy p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
 }
 
-.control-group input[type="range"]::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  width: 16px;
-  height: 16px;
-  background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
-  border-radius: 50%;
+.super-randomizer-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.super-randomizer-option {
+  position: relative;
+  display: inline-flex;
   cursor: pointer;
-  box-shadow: var(--shadow-sm);
+}
+
+.super-randomizer-option input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.super-randomizer-option span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 12px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--text-secondary);
   transition: all 0.2s ease;
 }
 
-.control-group input[type="range"]::-webkit-slider-thumb:hover {
-  transform: scale(1.2);
-  box-shadow: var(--shadow-glow);
+.super-randomizer-option span::before {
+  content: '';
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  background: transparent;
+  transition: all 0.2s ease;
 }
 
-.control-group select {
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-primary);
-  color: var(--text-primary);
-  padding: var(--space-xs) var(--space-sm);
-  border-radius: var(--radius-sm);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  outline: none;
-  cursor: pointer;
-}
-
-.control-group select:focus {
-  border-color: var(--accent-primary);
-  box-shadow: 0 0 0 2px rgba(0, 255, 136, 0.2);
-}
-
-.value-display {
+.super-randomizer-option input:checked + span {
+  background: rgba(0, 255, 176, 0.14);
+  border-color: rgba(0, 255, 176, 0.35);
   color: var(--accent-primary);
-  font-family: var(--font-mono);
-  font-size: 12px;
-  font-weight: 600;
-  min-width: 40px;
+  box-shadow: 0 0 16px rgba(0, 255, 176, 0.12);
+}
+
+.super-randomizer-option input:checked + span::before {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 10px rgba(0, 255, 176, 0.4);
+}
+
+.super-randomizer-option span:hover {
+  border-color: rgba(0, 255, 176, 0.25);
+}
+
+.super-randomizer-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: center;
+  justify-content: space-between;
+}
+
+.super-randomizer-interval {
+  flex: 1 1 220px;
+}
+
+.super-randomizer-status {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
   text-align: right;
 }
 
-/* Pads Section */
-.pads-section {
-  background: linear-gradient(135deg, rgba(255,255,255,0.02) 0%, rgba(255,255,255,0.01) 100%);
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-lg);
-  padding: var(--space-lg);
-  box-shadow: var(--shadow-md);
+.super-randomizer-status .label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--text-muted);
 }
 
-.pads-grid {
-  display: grid;
-  grid-auto-flow: column; /* single row */
-  grid-auto-columns: minmax(84px, 1fr); /* smaller pad width to fit line */
-  gap: var(--space-sm); /* tighter */
-  width: 100%;
-  overflow-x: auto; /* allow scroll if needed */
-  margin: 0 auto;
-}
-
-.pad {
-  background: linear-gradient(135deg, var(--bg-tertiary) 0%, var(--bg-secondary) 100%);
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-lg);
-  padding: var(--space-xs); /* tighter */
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 2px; /* tighter */
+.btn {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(135deg, rgba(24, 24, 40, 0.95), rgba(32, 32, 52, 0.95));
+  color: var(--text-primary);
+  font-size: 12px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  padding: 10px 18px;
+  border-radius: 999px;
   cursor: pointer;
-  transition: all 0.2s ease;
+  font-family: var(--font-mono);
+  transition: transform 0.15s ease, box-shadow 0.2s ease, border-color 0.2s ease;
   position: relative;
   overflow: hidden;
-  min-height: 64px; /* reduced from 80px */
 }
 
-.pad::before {
+.btn::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, transparent 30%, rgba(255,255,255,0.05) 50%, transparent 70%);
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.12), transparent 60%);
   opacity: 0;
   transition: opacity 0.2s ease;
 }
 
-.pad:hover::before {
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
+}
+
+.btn:hover::after {
   opacity: 1;
 }
 
-.pad:hover {
-  border-color: var(--border-secondary);
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-md);
+.btn:active {
+  transform: translateY(1px);
 }
 
-.pad:active {
-  transform: translateY(0) scale(0.98);
+.btn.primary {
+  background: linear-gradient(120deg, var(--accent-primary), var(--accent-secondary));
+  color: #041414;
+  border-color: rgba(0, 0, 0, 0.15);
+  box-shadow: 0 10px 24px rgba(0, 255, 176, 0.25);
 }
 
-.pad.active {
-  border-color: var(--accent-primary);
-  box-shadow: 0 0 30px rgba(0, 255, 136, 0.4);
-  animation: padPulse 0.3s ease-out;
+.btn.outline {
+  background: transparent;
+  border-color: rgba(0, 255, 176, 0.3);
+  color: var(--accent-primary);
 }
 
-@keyframes padPulse {
-  0% { transform: scale(1); }
-  50% { transform: scale(1.05); }
-  100% { transform: scale(1); }
+.btn.ghost {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: transparent;
+  color: var(--text-secondary);
 }
 
-.pad-label {
-  color: var(--text-primary);
-  font-family: var(--font-mono);
-  font-size: 11px; /* Increased from 11px */
-  font-weight: 700;
-  text-align: center;
-  text-transform: uppercase;
+.btn.danger {
+  background: linear-gradient(120deg, rgba(255, 84, 104, 0.9), rgba(255, 120, 140, 0.8));
+  border-color: rgba(255, 120, 140, 0.4);
+  color: #1f0509;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.control-group.inline {
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+}
+
+.control-group label {
+  font-size: 12px;
   letter-spacing: 0.5px;
-}
-
-.pad-sound {
-  font-family: var(--font-mono);
-  font-size: 9px; /* Increased from 9px */
-  color: var(--accent-primary); /* Changed from var(--accent-secondary) */
-  background: var(--bg-primary); /* Changed from var(--bg-tertiary) */
-  padding: 1px 5px; /* Increased padding */
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--accent-primary); /* Changed from var(--border-primary) */
   text-transform: uppercase;
-  letter-spacing: 0.3px;
-  font-weight: 600; /* Added font weight */
+  color: var(--text-muted);
 }
 
-.pad-key {
-  color: var(--text-muted);
+.value-display {
   font-family: var(--font-mono);
-  font-size: 9px;
-  background: var(--bg-tertiary);
-  padding: 2px 4px;
-  border-radius: var(--radius-xs);
-  border: 1px solid var(--border-primary);
+  font-size: 12px;
+  color: var(--accent-secondary);
+}
+
+input[type="range"],
+select {
+  accent-color: var(--accent-primary);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-sm);
+  padding: 4px;
+  color: var(--text-primary);
+}
+
+select {
+  padding: 8px 12px;
+}
+
+.studio {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: var(--space-lg);
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.panel {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+}
+
+.panel-header {
+  padding: var(--space-md);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.panel-header h2 {
+  margin: 0 0 4px;
+  font-size: 16px;
   font-weight: 600;
 }
 
-/* Tracks Section */
-.tracks-section {
-  background: linear-gradient(135deg, rgba(255,255,255,0.02) 0%, rgba(255,255,255,0.01) 100%);
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-lg);
-  padding: var(--space-md); /* Reduced from var(--space-lg) */
-  box-shadow: var(--shadow-md);
+.panel-header p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-secondary);
 }
 
-.track {
-  background: linear-gradient(135deg, var(--bg-tertiary) 0%, var(--bg-secondary) 100%);
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-lg);
-  margin-bottom: var(--space-sm); /* Reduced from var(--space-md) */
-  overflow: hidden;
-  box-shadow: var(--shadow-sm);
-  transition: all 0.2s ease;
+.panel-body {
+  padding: var(--space-md);
 }
 
-.track:hover {
-  border-color: var(--border-secondary);
-  box-shadow: var(--shadow-md);
-}
-
-.track.current-step {
-  border-color: var(--accent-warning);
-  box-shadow: 0 0 20px rgba(255, 170, 0, 0.3);
-}
-
-.track.current-step .track-header {
-  background: linear-gradient(135deg, rgba(255, 170, 0, 0.1) 0%, var(--bg-tertiary) 100%);
-}
-
-.track-header {
-  background: linear-gradient(135deg, var(--bg-elevated) 0%, var(--bg-tertiary) 100%);
-  border-bottom: 1px solid var(--border-primary);
-  padding: var(--space-sm); /* Reduced from var(--space-md) */
-  display: grid;
-  grid-template-columns: minmax(200px, 1fr) 60px 60px minmax(200px, 1fr);
-  gap: var(--space-md);
-  align-items: center;
-}
-
-.track-controls {
+.panel-body.stack {
   display: flex;
-  align-items: center;
-  gap: var(--space-md);
-}
-
-.track-select {
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-primary);
-  color: var(--text-primary);
-  padding: var(--space-sm);
-  border-radius: var(--radius-md);
-  font-family: var(--font-mono);
-  font-size: 12px;
-  outline: none;
-  cursor: pointer;
-  min-width: 120px;
-}
-
-.track-select:focus {
-  border-color: var(--accent-primary);
-  box-shadow: 0 0 0 2px rgba(0, 255, 136, 0.2);
-}
-
-.track-key {
-  color: var(--text-muted);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  background: var(--bg-tertiary);
-  padding: var(--space-xs) var(--space-sm);
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--border-primary);
-}
-
-.track-mute, .track-solo {
-  width: 40px;
-  height: 28px; /* Changed from 32px */
-  border-radius: var(--radius-md);
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  transition: all 0.2s ease;
-}
-
-.track-mute.active {
-  background: linear-gradient(135deg, var(--accent-danger) 0%, #ff3742 100%);
-  border-color: var(--accent-danger);
-  color: var(--text-primary);
-}
-
-.track-solo.active {
-  background: linear-gradient(135deg, var(--accent-secondary) 0%, #0099cc 100%);
-  border-color: var(--accent-secondary);
-  color: var(--text-primary);
-}
-
-.track-volume {
-  display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: var(--space-sm);
 }
 
-.volume-slider {
-  width: 80px;
-  height: 4px;
-  background: var(--bg-tertiary);
-  border-radius: 2px;
-  outline: none;
-  -webkit-appearance: none;
+.scale-preview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-family: var(--font-mono);
 }
 
-.volume-slider::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  width: 12px;
-  height: 12px;
-  background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
-  border-radius: 50%;
+.scale-preview span {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.soundboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: var(--space-sm);
+  padding: var(--space-md);
+}
+
+.soundboard-grid button {
+  min-height: 80px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
   cursor: pointer;
-  box-shadow: var(--shadow-sm);
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.soundboard-grid button span {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.soundboard-grid button:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+}
+
+.workspace {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.sequencer-toolbar {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: var(--space-md);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.toolbar-left,
+.toolbar-right {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.tracks-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.track {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+  --track-color: var(--accent-primary);
+}
+
+.track-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.06), rgba(0, 0, 0, 0.3));
+  border-left: 4px solid var(--track-color);
+}
+
+.track-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.track-name {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.track-type {
+  font-size: 11px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.track-key {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--accent-secondary);
+}
+
+.track-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.track-settings {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  align-items: center;
+}
+
+.volume-slider {
+  width: 140px;
 }
 
 .volume-meter {
-  width: 4px;
-  height: 24px; /* Increased from 20px */
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-primary);
-  border-radius: 2px;
+  width: 8px;
+  height: 46px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.06);
   overflow: hidden;
   position: relative;
-  box-shadow: inset 0 1px 3px rgba(0,0,0,0.3); /* Added inset shadow */
 }
 
 .volume-meter-fill {
   position: absolute;
   bottom: 0;
   left: 0;
-  width: 100%;
-  background: linear-gradient(to top, var(--accent-primary), var(--accent-secondary));
-  transition: height 0.1s ease, background 0.2s ease; /* Added background transition */
-  border-radius: 1px; /* Added border radius */
+  right: 0;
+  height: 0%;
+  background: linear-gradient(180deg, var(--track-color), rgba(255, 255, 255, 0.2));
+  transition: height 0.2s ease;
 }
 
-/* Grid */
+.track .control-group {
+  min-width: 140px;
+}
+
+.stepper {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.stepper-value {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
 .grid-container {
-  padding: var(--space-sm); /* Reduced from var(--space-md) */
+  overflow-x: auto;
+  padding: 0 var(--space-md) var(--space-md);
 }
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(16, 1fr);
-  gap: 2px; /* Reduced from 3px */
-  padding: var(--space-2xs, 4px); /* Reduced from var(--space-xs) */
+  grid-auto-rows: 54px;
+  gap: 6px;
+  min-width: min(100%, 32px * var(--steps, 16));
+}
+
+.grid[data-track] {
+  grid-template-columns: repeat(auto-fit, minmax(40px, 1fr));
 }
 
 .cell {
-  aspect-ratio: 2 / 1; /* Changed from 1 to 2/1 */
-  background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-tertiary) 100%);
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  transition: all 0.15s ease;
   position: relative;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  cursor: pointer;
+  transition: border-color 0.15s ease, transform 0.1s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
   overflow: hidden;
+}
+
+.cell:hover {
+  border-color: rgba(255, 255, 255, 0.15);
+  transform: translateY(-1px);
+}
+
+.cell.on {
+  color: #041414;
+  background: linear-gradient(135deg, rgba(0, 255, 176, 0.8), rgba(0, 192, 255, 0.7));
+  border-color: rgba(0, 255, 176, 0.4);
+}
+
+.cell.melody.on {
+  background: linear-gradient(135deg, rgba(255, 117, 195, 0.85), rgba(0, 192, 255, 0.7));
+  color: #1c0b1c;
+}
+
+.cell.vel-1.on {
+  opacity: 0.75;
+}
+
+.cell.vel-2.on {
+  opacity: 0.9;
+}
+
+.cell.vel-3.on {
+  opacity: 1;
+}
+
+.cell.step {
+  box-shadow: 0 0 0 2px rgba(0, 255, 176, 0.4);
+}
+
+.cell .note-label {
+  position: relative;
+  z-index: 2;
 }
 
 .cell::before {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, transparent 30%, rgba(255,255,255,0.05) 50%, transparent 70%);
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.25), transparent 65%);
   opacity: 0;
   transition: opacity 0.2s ease;
 }
 
-.cell:hover::before {
+.cell.on::before {
   opacity: 1;
 }
 
-.cell:hover {
-  border-color: var(--border-secondary);
-  transform: scale(1.05);
-}
-
-/* Lit cells (pre-play visibility) */
-.cell.on {
-  --cell-color: var(--accent-primary);
-  border-color: var(--cell-color);
-  background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-tertiary) 100%);
-  box-shadow: 0 0 10px rgba(0,0,0,0.2);
-}
-
-.cell.on::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: rgba(var(--cell-color-rgb, 0,255,136), 0.35);
-  transition: opacity 0.15s ease, background 0.15s ease;
-}
-
-/* Velocity levels */
-.cell.on.v1::after { background: rgba(var(--cell-color-rgb, 0,255,136), 0.35); }
-.cell.on.v2::after { background: rgba(var(--cell-color-rgb, 0,255,136), 0.55); }
-.cell.on.v3::after { background: rgba(var(--cell-color-rgb, 0,255,136), 0.8); }
-
-/* Current step indicator while playing */
-.cell.step {
-  border-color: var(--accent-warning);
-  box-shadow: 0 0 15px rgba(255, 170, 0, 0.6); /* Increased opacity */
-  animation: stepPulse 0.5s ease-out;
-  background: linear-gradient(135deg, rgba(255, 170, 0, 0.2) 0%, rgba(255, 170, 0, 0.1) 100%); /* Added background */
-}
-
-@keyframes stepPulse {
-  0% { transform: scale(1); }
-  50% { transform: scale(1.15); } /* Increased scale */
-  100% { transform: scale(1); }
-}
-
-/* Footer */
-.footer {
-  background: linear-gradient(135deg, rgba(255,255,255,0.02) 0%, rgba(255,255,255,0.01) 100%);
-  border: 1px solid var(--border-primary);
+.pads-section {
+  background: var(--surface);
   border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: var(--space-md);
+  box-shadow: var(--shadow-soft);
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: var(--space-md);
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.section-header p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.pads-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--space-sm);
+}
+
+.pad {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.05), rgba(0, 0, 0, 0.25));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.pad:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 16px 26px rgba(0, 0, 0, 0.3);
+}
+
+.pad.active {
+  transform: translateY(-4px) scale(1.02);
+  box-shadow: 0 16px 32px rgba(0, 255, 176, 0.25);
+}
+
+.pad-label {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.pad-sound {
+  font-size: 18px;
+  font-family: var(--font-mono);
+  color: var(--accent-secondary);
+}
+
+.pad-key {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.footer {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: var(--space-md);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  align-items: center;
+  justify-content: space-between;
+}
+
+.footer-info {
+  flex: 1 1 360px;
+  color: var(--text-secondary);
+}
+
+.footer-info h3 {
+  margin: 0 0 6px;
+  font-size: 16px;
+}
+
+.footer-meta {
+  display: flex;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.stat .label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--text-muted);
+}
+
+.instrument-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(5, 5, 12, 0.8);
+  backdrop-filter: blur(12px);
+  display: none;
+  align-items: center;
+  justify-content: center;
   padding: var(--space-lg);
+  z-index: 100;
+}
+
+.instrument-overlay.open {
+  display: flex;
+}
+
+.overlay-content {
+  background: var(--surface-strong);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 28px 48px rgba(0, 0, 0, 0.45);
+  max-width: 840px;
+  width: 100%;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.overlay-header {
+  padding: var(--space-md);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: var(--space-lg);
-  box-shadow: var(--shadow-md);
-}
-
-.presets-container {
-  display: flex;
-  flex-wrap: wrap;
   gap: var(--space-sm);
-  max-width: 60%;
 }
 
-.preset-chip {
-  background: linear-gradient(135deg, var(--bg-elevated) 0%, var(--bg-tertiary) 100%);
-  border: 1px solid var(--border-primary);
-  color: var(--text-secondary);
-  padding: var(--space-xs) var(--space-sm);
+.overlay-header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.instrument-grid {
+  padding: var(--space-md);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--space-md);
+  overflow-y: auto;
+}
+
+.instrument-card {
+  background: rgba(255, 255, 255, 0.04);
   border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
   cursor: pointer;
-  user-select: none;
-  transition: all 0.2s ease;
-  font-family: var(--font-mono);
+  transition: transform 0.15s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.instrument-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(0, 255, 176, 0.4);
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
+}
+
+.instrument-card .badge {
+  align-self: flex-start;
+  padding: 4px 10px;
+  border-radius: 999px;
   font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-}
-
-.preset-chip:hover {
-  background: linear-gradient(135deg, var(--bg-hover) 0%, var(--bg-elevated) 100%);
-  border-color: var(--border-secondary);
-  color: var(--text-primary);
-  transform: translateY(-1px);
-}
-
-.preset-chip.active {
-  background: linear-gradient(135deg, var(--accent-primary) 0%, #00cc6a 100%);
-  border-color: var(--accent-primary);
-  color: var(--bg-primary);
-  box-shadow: 0 0 15px rgba(0, 255, 136, 0.3);
-}
-
-.footer-controls {
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
-}
-
-.manual-buttons {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-md);
-  min-width: 150px;
-}
-
-.button-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
-}
-
-.button-label {
-  color: var(--text-muted);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  margin-bottom: var(--space-xs);
+  background: rgba(0, 255, 176, 0.16);
+  color: var(--accent-primary);
 }
 
-.manual-btn {
-  width: 100%;
-  justify-content: center;
-  font-size: 11px;
-  padding: var(--space-sm) var(--space-md);
+.instrument-card h3 {
+  margin: 0;
+  font-size: 16px;
 }
 
-/* Responsive */
-@media (max-width: 1200px) {
-  .app {
-    padding: var(--space-md);
-    gap: var(--space-md);
+.instrument-card p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.track.selected {
+  border-color: var(--border-strong);
+  box-shadow: 0 0 0 1px rgba(0, 255, 176, 0.35), var(--shadow-soft);
+}
+
+.track .btn.active {
+  background: linear-gradient(120deg, rgba(0, 255, 176, 0.85), rgba(0, 192, 255, 0.8));
+  color: #041410;
+  border-color: transparent;
+}
+
+@media (max-width: 1100px) {
+  .studio {
+    grid-template-columns: 1fr;
   }
-  
+
+  .sidebar {
+    order: 2;
+  }
+
+  .workspace {
+    order: 1;
+  }
+}
+
+@media (max-width: 720px) {
+  .app {
+    width: 100%;
+    padding: var(--space-md);
+  }
+
   .header {
     flex-direction: column;
-    gap: var(--space-md);
   }
-  
-  .transport {
-    flex-wrap: wrap;
+
+  .transport-main {
     justify-content: center;
   }
-  
-  .pads-grid {
-    grid-template-columns: repeat(4, 1fr);
-  }
-  
-  .track-header {
-    grid-template-columns: 1fr;
-    gap: var(--space-sm);
-  }
-  
+
   .footer {
     flex-direction: column;
-    gap: var(--space-md);
+    align-items: flex-start;
   }
-  
-  .presets-container {
-    max-width: 100%;
-    justify-content: center;
+
+  .soundboard-grid {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   }
-  
-  .manual-buttons {
-    flex-direction: row;
-    justify-content: center;
-    min-width: auto;
-  }
-  
-  .button-group {
-    align-items: center;
+
+  .instrument-grid {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   }
 }
-
-@media (max-width: 768px) {
-  .pads-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-  
-  .grid {
-    grid-template-columns: repeat(8, 1fr);
-  }
-  
-  .control-group input[type="range"] {
-    width: 80px;
-  }
-}
-
-/* Loading Animation */
-.loading {
-  display: inline-block;
-  width: 20px;
-  height: 20px;
-  border: 2px solid var(--border-primary);
-  border-radius: 50%;
-  border-top-color: var(--accent-primary);
-  animation: spin 1s ease-in-out infinite;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-
-/* Utility Classes */
-.text-center { text-align: center; }
-.text-muted { color: var(--text-muted); }
-.text-accent { color: var(--accent-primary); }
-.hidden { display: none; }
-.flex { display: flex; }
-.flex-center { display: flex; align-items: center; justify-content: center; }
-.gap-sm { gap: var(--space-sm); }
-.gap-md { gap: var(--space-md); }

--- a/ui.js
+++ b/ui.js
@@ -1,336 +1,424 @@
-// UI Module - DOM manipulation and event handling
+// 8Beat Chiptune Studio - Interface & Interaction Layer
 
-// Helper: convert hex color like #00ff88 to "0,255,136"
-function hexToRgbString(hex) {
-  if (!hex) return '0,255,136';
-  const m = hex.trim().toLowerCase().match(/^#?([a-f0-9]{3}|[a-f0-9]{6})$/i);
-  if (!m) return '0,255,136';
-  let h = m[1];
-  if (h.length === 3) {
-    h = h.split('').map(c => c + c).join('');
-  }
-  const r = parseInt(h.slice(0, 2), 16);
-  const g = parseInt(h.slice(2, 4), 16);
-  const b = parseInt(h.slice(4, 6), 16);
-  return `${r},${g},${b}`;
-}
+const SOUND_LABELS = {
+  melody: 'Lead',
+  bass: 'Bass',
+  harmony: 'Chord',
+  sequence: 'Arp',
+  drum: 'Drum',
+  sample: 'Sample'
+};
 
-// Build the main UI
-function buildUI() {
-  const app = document.querySelector('.app');
-  
-  // Build tracks
-  state.tracks = defaultTracks.map((track, i) => ({
-    ...track,
-    id: i,
-    steps: new Array(state.steps).fill(0),
-    volume: 1.0,
-    muted: false,
-    soloed: false,
-    sample: null
-  }));
-  
+const superRandomizerState = {
+  running: false,
+  toggles: {
+    tracks: true,
+    instruments: true,
+    key: true,
+    tempo: true,
+    interval: true
+  },
+  baseInterval: 8,
+  timerId: null,
+  countdownId: null,
+  nextTriggerTime: 0
+};
+
+function buildInterface() {
   buildTracks();
   buildPads();
-  updateDisplay();
+  renderSoundboard();
+  renderInstrumentOverlay();
+  refreshScalePreview();
+  updateScaleSummary();
 }
 
-// Build track UI
 function buildTracks() {
   const rack = document.getElementById('rack');
+  if (!rack) return;
   rack.innerHTML = '';
-  
+
   state.tracks.forEach((track, idx) => {
-    const trackEl = document.createElement('div');
+    const trackEl = document.createElement('article');
     trackEl.className = 'track';
+    trackEl.dataset.track = String(idx);
+    trackEl.style.setProperty('--track-color', track.color || 'var(--accent-primary)');
+
+    const typeLabel = track.category || (track.type === 'melody' ? 'Melody' : track.type.charAt(0).toUpperCase() + track.type.slice(1));
+    const registerLabel = getTrackRegisterLabel(track);
+    const dutyValue = typeof track.dutyCycle === 'number' ? track.dutyCycle : 0.5;
+
     trackEl.innerHTML = `
       <div class="track-header">
-        <div class="track-controls">
-          <select class="track-select">
-            ${waveOptions.map(w => `<option value="${w}" ${w === track.type ? 'selected' : ''}>${w}</option>`).join('')}
-          </select>
-          <div class="track-key">${track.key}</div>
+        <div class="track-meta">
+          <span class="track-name">${track.name}</span>
+          <span class="track-type">${typeLabel}</span>
+          <span class="track-key">Key: ${track.key || '-'}</span>
         </div>
-        <button class="btn track-mute">Mute</button>
-        <button class="btn track-solo">Solo</button>
-        <div class="track-volume">
-          <input type="range" class="volume-slider" min="0" max="1" step="0.01" value="${track.volume}">
-          <div class="volume-meter">
-            <div class="volume-meter-fill" style="height: ${track.volume * 100}%"></div>
+        <div class="track-actions">
+          <button class="btn ghost track-mute${track.muted ? ' active' : ''}">${track.muted ? 'Unmute' : 'Mute'}</button>
+          <button class="btn ghost track-solo${track.soloed ? ' active' : ''}">${track.soloed ? 'Soloed' : 'Solo'}</button>
+          <button class="btn ghost track-remove">Remove</button>
+        </div>
+      </div>
+      <div class="track-settings">
+        <div class="control-group">
+          <label>Volume</label>
+          <input type="range" class="volume-slider" min="0" max="1" step="0.01" value="${track.volume}" ${track.muted ? 'disabled' : ''}>
+          <div class="volume-meter"><div class="volume-meter-fill" style="height:${track.volume * 100}%"></div></div>
+        </div>
+        ${(track.type === 'melody' || track.type === 'arpeggio') ? `
+          <div class="control-group">
+            <label>Register</label>
+            <div class="stepper">
+              <button class="btn ghost stepper-btn" data-action="register-down">-</button>
+              <span class="stepper-value">${registerLabel}</span>
+              <button class="btn ghost stepper-btn" data-action="register-up">+</button>
+            </div>
           </div>
-        </div>
+        ` : ''}
+        ${(track.waveform === 'pulse') ? `
+          <div class="control-group">
+            <label>Pulse Width</label>
+            <input type="range" class="duty-slider" min="0.05" max="0.95" step="0.01" value="${dutyValue.toFixed(2)}">
+            <span class="value-display duty-value">${dutyValue.toFixed(2)}</span>
+          </div>
+        ` : ''}
       </div>
       <div class="grid-container">
         <div class="grid" data-track="${idx}"></div>
       </div>
     `;
-    
+
     rack.appendChild(trackEl);
-    
-    // Set per-track color for grid cells
-    const gridEl = trackEl.querySelector(`.grid[data-track="${idx}"]`);
-    if (gridEl) {
-      gridEl.style.setProperty('--cell-color', track.color || 'var(--accent-primary)');
-      gridEl.style.setProperty('--cell-color-rgb', hexToRgbString(track.color));
-    }
-    
     setupTrackEvents(trackEl, track, idx);
   });
-  
+
   rebuildGrids();
+  highlightSelectedTrack();
 }
 
-// Setup track event listeners
+function getTrackRegisterLabel(track) {
+  const slice = getTrackScale(track);
+  if (!slice.length) return 'N/A';
+  const first = slice[0]?.label || '';
+  const last = slice[slice.length - 1]?.label || first;
+  return slice.length > 1 ? `${first} → ${last}` : first;
+}
+
 function setupTrackEvents(trackEl, track, idx) {
-  const select = trackEl.querySelector('.track-select');
+  trackEl.addEventListener('click', (event) => {
+    const target = event.target;
+    if (target.closest('button') || target.closest('.grid')) return;
+    selectTrack(idx);
+  });
+
   const muteBtn = trackEl.querySelector('.track-mute');
   const soloBtn = trackEl.querySelector('.track-solo');
+  const removeBtn = trackEl.querySelector('.track-remove');
   const volSlider = trackEl.querySelector('.volume-slider');
   const meterFill = trackEl.querySelector('.volume-meter-fill');
-  
-  // store last non-muted volume
-  track._lastVolume = track._lastVolume ?? track.volume ?? 1.0;
-  
-  select.addEventListener('change', (e) => {
-    track.type = e.target.value;
-    if (track.type === 'sample' && !track.sample) {
-      document.getElementById('loadSampleFile').click();
-    }
+  const dutySlider = trackEl.querySelector('.duty-slider');
+  const dutyValue = trackEl.querySelector('.duty-value');
+  const stepperBtns = trackEl.querySelectorAll('.stepper-btn');
+
+  if (muteBtn) {
+    muteBtn.addEventListener('click', () => {
+      track.muted = !track.muted;
+      muteBtn.classList.toggle('active', track.muted);
+      muteBtn.textContent = track.muted ? 'Unmute' : 'Mute';
+      if (track.muted) {
+        track._lastVolume = track.volume;
+        track.volume = 0;
+        if (volSlider) volSlider.value = '0';
+        if (volSlider) volSlider.disabled = true;
+        if (meterFill) meterFill.style.height = '0%';
+      } else {
+        const restore = typeof track._lastVolume === 'number' ? track._lastVolume : 0.85;
+        track.volume = restore;
+        if (volSlider) {
+          volSlider.value = String(restore);
+          volSlider.disabled = false;
+        }
+        if (meterFill) meterFill.style.height = `${restore * 100}%`;
+      }
+    });
+  }
+
+  if (soloBtn) {
+    soloBtn.addEventListener('click', () => {
+      track.soloed = !track.soloed;
+      soloBtn.classList.toggle('active', track.soloed);
+      soloBtn.textContent = track.soloed ? 'Soloed' : 'Solo';
+      if (track.soloed && track.muted && muteBtn) {
+        muteBtn.click();
+      }
+    });
+  }
+
+  if (removeBtn) {
+    removeBtn.addEventListener('click', () => removeTrack(idx));
+  }
+
+  if (volSlider) {
+    volSlider.addEventListener('input', (e) => {
+      const value = parseFloat(e.target.value);
+      track.volume = isFinite(value) ? value : 0;
+      if (meterFill) meterFill.style.height = `${track.volume * 100}%`;
+    });
+  }
+
+  if (dutySlider) {
+    dutySlider.addEventListener('input', (e) => {
+      const value = parseFloat(e.target.value);
+      track.dutyCycle = clamp(isFinite(value) ? value : 0.5, 0.05, 0.95);
+      if (dutyValue) dutyValue.textContent = track.dutyCycle.toFixed(2);
+    });
+  }
+
+  stepperBtns.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const action = btn.dataset.action;
+      if (action === 'register-down') {
+        adjustTrackRegister(idx, -2);
+      } else if (action === 'register-up') {
+        adjustTrackRegister(idx, 2);
+      }
+      const valueEl = trackEl.querySelector('.stepper-value');
+      if (valueEl) valueEl.textContent = getTrackRegisterLabel(track);
+    });
   });
-  
-  muteBtn.addEventListener('click', () => {
-    track.muted = !track.muted;
-    muteBtn.classList.toggle('active', track.muted);
-    if (track.muted) {
-      // remember current volume and set to 0
-      track._lastVolume = track.volume;
-      track.volume = 0;
-      volSlider.value = '0';
-      volSlider.disabled = true;
-      meterFill.style.height = '0%';
-    } else {
-      // restore volume
-      const restore = typeof track._lastVolume === 'number' ? track._lastVolume : 1.0;
-      track.volume = restore;
-      volSlider.value = String(restore);
-      volSlider.disabled = false;
-      meterFill.style.height = `${restore * 100}%`;
-    }
-    // if soloed and muted, un-solo to avoid confusion
-    if (track.muted) soloBtn.classList.remove('active');
-  });
-  
-  soloBtn.addEventListener('click', () => {
-    track.soloed = !track.soloed;
-    soloBtn.classList.toggle('active', track.soloed);
-    if (track.soloed) {
-      // ensure not muted
-      if (track.muted) muteBtn.click();
-    }
-  });
-  
-  volSlider.addEventListener('input', (e) => {
-    const val = parseFloat(e.target.value);
-    track.volume = isFinite(val) ? val : 0;
-    meterFill.style.height = `${track.volume * 100}%`;
-    // visual feedback color
-    meterFill.style.background = track.volume > 0.8 ? 
-      'linear-gradient(to top, #ff4444, #ff6666)' : 
-      'linear-gradient(to top, var(--accent-primary), var(--accent-secondary))';
-  });
-  
-  // Initialize volume meter and slider state
-  volSlider.value = String(track.volume);
-  volSlider.disabled = !!track.muted;
-  meterFill.style.height = `${track.volume * 100}%`;
 }
 
-// Build pads section
 function buildPads() {
-  const padsSection = document.querySelector('.pads-section');
   const padsGrid = document.querySelector('.pads-grid');
-  
+  if (!padsGrid) return;
   padsGrid.innerHTML = '';
-  
+
   state.tracks.forEach((track, idx) => {
     const pad = document.createElement('div');
     pad.className = 'pad';
-    pad.dataset.track = idx;
-    
-    // Create more descriptive sound labels
-    const soundLabels = {
-      'kick': 'BOOM',
-      'snare': 'CRACK', 
-      'clap': 'CLAP',
-      'hat': 'TSS',
-      'square': 'BEEP',
-      'triangle': 'DING',
-      'sample': 'SAMPLE'
-    };
-    
-    const soundLabel = soundLabels[track.type] || track.type.toUpperCase();
-    
+    pad.dataset.track = String(idx);
+
+    const label = track.name;
+    const typeKey = track.category ? track.category.toLowerCase() : track.type;
+    const soundLabel = SOUND_LABELS[typeKey] || SOUND_LABELS[track.type] || track.type.toUpperCase();
+
     pad.innerHTML = `
-      <div class="pad-label">${track.name}</div>
+      <div class="pad-label">${label}</div>
       <div class="pad-sound">${soundLabel}</div>
-      <div class="pad-key">${track.key}</div>
+      <div class="pad-key">${track.key || ''}</div>
     `;
-    
-    pad.addEventListener('click', () => playPad(idx));
+
     pad.addEventListener('mousedown', () => {
       pad.classList.add('active');
       playPad(idx);
     });
     pad.addEventListener('mouseup', () => pad.classList.remove('active'));
     pad.addEventListener('mouseleave', () => pad.classList.remove('active'));
-    
+    pad.addEventListener('click', () => playPad(idx));
+
     padsGrid.appendChild(pad);
   });
 }
 
-// Play pad with visual feedback
-function playPad(trackIdx) {
+async function playPad(trackIdx) {
   const track = state.tracks[trackIdx];
   if (!track) return;
-  
-  const pad = document.querySelector(`[data-track="${trackIdx}"]`);
-  pad.classList.add('active');
-  
-  setTimeout(() => pad.classList.remove('active'), 300);
-  
-  playTrack(track, engine.currentTime());
+  await engine.resume();
+  const pad = document.querySelector(`.pad[data-track="${trackIdx}"]`);
+  if (pad) {
+    pad.classList.add('active');
+    setTimeout(() => pad.classList.remove('active'), 180);
+  }
+
+  const now = engine.currentTime();
+  if (track.type === 'drum' || track.type === 'sample') {
+    playTrack(track, now, { velocity: 3 });
+  } else {
+    const slice = getTrackScale(track);
+    const noteIndex = clamp(track.previewNoteIndex || 0, 0, Math.max(0, slice.length - 1));
+    playTrack(track, now, { noteIndex, velocity: 3 });
+  }
 }
 
-// Rebuild all grids
 function rebuildGrids() {
   state.tracks.forEach((track, idx) => {
     const grid = document.querySelector(`.grid[data-track="${idx}"]`);
     if (!grid) return;
-    
-    // Ensure per-track color is applied (in case of rebuild)
-    grid.style.setProperty('--cell-color', track.color || 'var(--accent-primary)');
-    grid.style.setProperty('--cell-color-rgb', hexToRgbString(track.color));
-    
     grid.innerHTML = '';
-    grid.style.gridTemplateColumns = `repeat(${state.steps}, 1fr)`;
-    
-    for (let i = 0; i < state.steps; i++) {
+    grid.style.setProperty('--track-color', track.color || 'var(--accent-primary)');
+    grid.style.setProperty('--steps', state.steps);
+
+    for (let step = 0; step < state.steps; step++) {
       const cell = document.createElement('div');
       cell.className = 'cell';
-      cell.dataset.step = i;
-      cell.dataset.track = idx;
-      
+      cell.dataset.step = String(step);
+      cell.dataset.track = String(idx);
+
       cell.addEventListener('click', (e) => {
-        e.preventDefault();
-        cycleCell(track.id, i);
+        if (e.shiftKey) {
+          bumpVelocity(idx, step);
+        } else {
+          cycleCell(idx, step);
+        }
       });
-      
+
       cell.addEventListener('contextmenu', (e) => {
         e.preventDefault();
-        decreaseCell(track.id, i);
+        decreaseCell(idx, step);
       });
-      
+
       grid.appendChild(cell);
     }
-    
-    updateTrackGrid(track.id);
+
+    updateTrackGrid(idx);
   });
 }
 
-// Update a track's grid display
-function updateTrackGrid(trackId) {
-  const track = state.tracks[trackId];
+function updateTrackGrid(trackIndex) {
+  const track = state.tracks[trackIndex];
   if (!track) return;
-  
-  const grid = document.querySelector(`.grid[data-track="${trackId}"]`);
+  const grid = document.querySelector(`.grid[data-track="${trackIndex}"]`);
   if (!grid) return;
-  
-  // Ensure color variable is set
-  grid.style.setProperty('--cell-color', track.color || 'var(--accent-primary)');
-  grid.style.setProperty('--cell-color-rgb', hexToRgbString(track.color));
-  
-  track.steps.forEach((level, step) => {
-    const cell = grid.querySelector(`[data-step="${step}"]`);
-    if (!cell) return;
-    
-    // Reset classes
-    cell.classList.remove('v1', 'v2', 'v3', 'on');
-    
-    if (level > 0) {
-      cell.classList.add('on');
-      if (level === 1) cell.classList.add('v1');
-      else if (level === 2) cell.classList.add('v2');
-      else cell.classList.add('v3');
+
+  const cells = grid.querySelectorAll('.cell');
+  const slice = getTrackScale(track);
+
+  cells.forEach((cell) => {
+    const step = parseInt(cell.dataset.step, 10);
+    cell.classList.remove('on', 'melody', 'vel-1', 'vel-2', 'vel-3', 'step');
+    cell.innerHTML = '';
+
+    if (track.type === 'drum' || track.type === 'sample') {
+      const level = track.steps[step] || 0;
+      if (level > 0) {
+        cell.classList.add('on', `vel-${clamp(level, 1, 3)}`);
+      }
+    } else {
+      const evt = track.steps[step];
+      if (evt) {
+        const vel = clamp(evt.velocity || 2, 1, 3);
+        const note = slice[clamp(evt.noteIndex || 0, 0, Math.max(0, slice.length - 1))];
+        cell.classList.add('on', 'melody', `vel-${vel}`);
+        if (note) {
+          cell.innerHTML = `<span class="note-label">${note.label}</span>`;
+        }
+      }
     }
   });
 }
 
-// Cycle cell velocity
-function cycleCell(trackId, step) {
-  const track = state.tracks[trackId];
+function cycleCell(trackIndex, step) {
+  const track = state.tracks[trackIndex];
   if (!track) return;
-  
-  const current = track.steps[step] || 0;
-  track.steps[step] = (current + 1) % 4;
-  
-  updateTrackGrid(trackId);
+
+  if (track.type === 'drum' || track.type === 'sample') {
+    const current = track.steps[step] || 0;
+    track.steps[step] = (current + 1) % 4;
+  } else {
+    const slice = getTrackScale(track);
+    if (!slice.length) return;
+    const current = track.steps[step];
+    if (!current) {
+      const noteIndex = clamp(track.previewNoteIndex || 0, 0, slice.length - 1);
+      track.steps[step] = { noteIndex, velocity: 2 };
+    } else if (current.noteIndex >= slice.length - 1) {
+      track.steps[step] = null;
+    } else {
+      current.noteIndex += 1;
+    }
+  }
+
+  updateTrackGrid(trackIndex);
 }
 
-// Decrease cell velocity
-function decreaseCell(trackId, step) {
-  const track = state.tracks[trackId];
+function decreaseCell(trackIndex, step) {
+  const track = state.tracks[trackIndex];
   if (!track) return;
-  
-  const current = track.steps[step] || 0;
-  track.steps[step] = Math.max(0, current - 1);
-  
-  updateTrackGrid(trackId);
+
+  if (track.type === 'drum' || track.type === 'sample') {
+    const current = track.steps[step] || 0;
+    track.steps[step] = Math.max(0, current - 1);
+  } else {
+    const current = track.steps[step];
+    if (!current) return;
+    if (current.noteIndex <= 0) {
+      track.steps[step] = null;
+    } else {
+      current.noteIndex -= 1;
+    }
+  }
+
+  updateTrackGrid(trackIndex);
 }
 
-// Set cell value
-function setCell(trackId, step, value) {
-  const track = state.tracks[trackId];
+function bumpVelocity(trackIndex, step) {
+  const track = state.tracks[trackIndex];
   if (!track) return;
-  
-  track.steps[step] = clamp(value, 0, 3);
-  updateTrackGrid(trackId);
+
+  if (track.type === 'drum' || track.type === 'sample') {
+    const current = track.steps[step] || 0;
+    track.steps[step] = current ? ((current % 3) + 1) : 1;
+  } else {
+    const slice = getTrackScale(track);
+    if (!slice.length) return;
+    const current = track.steps[step];
+    if (!current) {
+      const noteIndex = clamp(track.previewNoteIndex || 0, 0, slice.length - 1);
+      track.steps[step] = { noteIndex, velocity: 1 };
+    } else {
+      current.velocity = ((current.velocity || 1) % 3) + 1;
+    }
+  }
+
+  updateTrackGrid(trackIndex);
 }
 
-// Update display values
 function updateDisplay() {
   const bpmValEl = document.getElementById('bpmVal');
   const swingValEl = document.getElementById('swingVal');
   const driveValEl = document.getElementById('driveVal');
   const delayValEl = document.getElementById('delayVal');
-  
+  const stepCounter = document.getElementById('stepCounter');
+
   if (bpmValEl) bpmValEl.textContent = state.bpm;
-  if (swingValEl) swingValEl.textContent = Math.round(state.swing * 100) + '%';
-  
-  // Safely read from sliders so we don't depend on undefined state fields
+  if (swingValEl) swingValEl.textContent = `${Math.round(state.swing * 100)}%`;
+
   const driveInput = document.getElementById('drive');
   const delayInput = document.getElementById('delayMix');
-  const driveVal = driveInput ? parseFloat(driveInput.value) : 0.2;
-  const delayVal = delayInput ? parseFloat(delayInput.value) : 0.15;
-  
-  if (driveValEl) driveValEl.textContent = driveVal.toFixed(2);
-  if (delayValEl) delayValEl.textContent = delayVal.toFixed(2);
-  
-  // Update step counter
-  const currentStep = state.playing ? (state.position % state.steps) + 1 : 0;
-  const stepCounter = document.getElementById('stepCounter');
+  if (driveValEl && driveInput) driveValEl.textContent = parseFloat(driveInput.value).toFixed(2);
+  if (delayValEl && delayInput) delayValEl.textContent = parseFloat(delayInput.value).toFixed(2);
+
   if (stepCounter) {
-    stepCounter.textContent = currentStep;
+    const step = state.playing ? (state.position % state.steps) + 1 : 0;
+    stepCounter.textContent = step;
   }
 }
 
-// Setup all event listeners
 function setupEventListeners() {
-  // Transport controls
   const playBtn = document.getElementById('play');
   const stopBtn = document.getElementById('stop');
   const recordBtn = document.getElementById('recordBtn');
   const downloadBtn = document.getElementById('downloadBtn');
-  
+  const bpmSlider = document.getElementById('bpm');
+  const stepsSelect = document.getElementById('steps');
+  const swingSlider = document.getElementById('swing');
+  const driveSlider = document.getElementById('drive');
+  const delaySlider = document.getElementById('delayMix');
+  const scaleRoot = document.getElementById('scaleRoot');
+  const scaleMode = document.getElementById('scaleMode');
+  const addTrackBtn = document.getElementById('addTrackBtn');
+  const randomizeBtn = document.getElementById('randomizeBtn');
+  const randomizeScaleBtn = document.getElementById('randomizeScaleBtn');
+  const clearBtn = document.getElementById('clearBtn');
+  const loadSampleBtn = document.getElementById('loadSampleBtn');
+  const loadSampleFile = document.getElementById('loadSampleFile');
+  const closeOverlayBtn = document.getElementById('closeOverlayBtn');
+  const superRandomToggle = document.getElementById('superRandomToggle');
+  const superRandomIntervalSlider = document.getElementById('superRandomInterval');
+  const superRandomOptions = document.querySelectorAll('.super-randomizer-option input');
+
   if (playBtn) {
     playBtn.addEventListener('click', () => {
       if (state.playing) {
@@ -340,561 +428,631 @@ function setupEventListeners() {
       }
     });
   }
-  
+
   if (stopBtn) {
     stopBtn.addEventListener('click', stop);
   }
-  
+
   if (recordBtn) {
     recordBtn.addEventListener('click', toggleRecording);
   }
-  
+
   if (downloadBtn) {
     downloadBtn.addEventListener('click', downloadRecording);
   }
-  
-  // Tempo and controls
-  const bpmSlider = document.getElementById('bpm');
-  const stepsSelect = document.getElementById('steps');
-  const swingSlider = document.getElementById('swing');
-  const driveSlider = document.getElementById('drive');
-  const delayMixSlider = document.getElementById('delayMix');
-  
+
   if (bpmSlider) {
     bpmSlider.addEventListener('input', (e) => {
-      state.bpm = parseInt(e.target.value);
+      state.bpm = parseInt(e.target.value, 10);
       updateDisplay();
     });
   }
-  
+
   if (stepsSelect) {
     stepsSelect.addEventListener('change', (e) => {
-      state.steps = parseInt(e.target.value);
-      state.tracks.forEach(track => {
-        const newSteps = new Array(state.steps).fill(0);
-        track.steps.forEach((val, i) => {
-          if (i < state.steps) newSteps[i] = val;
-        });
-        track.steps = newSteps;
-      });
+      const value = parseInt(e.target.value, 10);
+      setStepsPerTrack(value);
+      buildTracks();
+      buildPads();
+      updateDisplay();
+    });
+  }
+
+  if (swingSlider) {
+    swingSlider.addEventListener('input', (e) => {
+      state.swing = parseFloat(e.target.value) || 0;
+      updateDisplay();
+    });
+  }
+
+  if (driveSlider) {
+    driveSlider.addEventListener('input', (e) => {
+      const value = parseFloat(e.target.value) || 0;
+      engine.setDrive(value);
+      updateDisplay();
+    });
+  }
+
+  if (delaySlider) {
+    delaySlider.addEventListener('input', (e) => {
+      const value = parseFloat(e.target.value) || 0;
+      engine.setDelayMix(value);
+      updateDisplay();
+    });
+  }
+
+  if (scaleRoot) {
+    scaleRoot.addEventListener('change', () => {
+      updateScale(scaleRoot.value, state.scale.mode);
+      refreshScalePreview();
+      updateScaleSummary();
       rebuildGrids();
     });
   }
-  
-  if (swingSlider) {
-    swingSlider.addEventListener('input', (e) => {
-      state.swing = parseFloat(e.target.value);
-      updateDisplay();
+
+  if (scaleMode) {
+    scaleMode.addEventListener('change', () => {
+      updateScale(state.scale.root, scaleMode.value);
+      refreshScalePreview();
+      updateScaleSummary();
+      rebuildGrids();
     });
   }
-  
-  if (driveSlider) {
-    driveSlider.addEventListener('input', (e) => {
-      const val = parseFloat(e.target.value);
-      engine.setDrive(val);
-      updateDisplay();
-    });
+
+  if (randomizeScaleBtn) {
+    randomizeScaleBtn.addEventListener('click', randomizeScale);
   }
-  
-  if (delayMixSlider) {
-    delayMixSlider.addEventListener('input', (e) => {
-      const val = parseFloat(e.target.value);
-      engine.setDelayMix(val);
-      updateDisplay();
-    });
+
+  if (addTrackBtn) {
+    addTrackBtn.addEventListener('click', openInstrumentOverlay);
   }
-  
-  // Sample loading
-  const loadSampleBtn = document.getElementById('loadSampleBtn');
-  const loadSampleFile = document.getElementById('loadSampleFile');
-  
-  if (loadSampleBtn) {
-    loadSampleBtn.addEventListener('click', () => {
-      loadSampleFile.click();
-    });
+
+  if (closeOverlayBtn) {
+    closeOverlayBtn.addEventListener('click', closeInstrumentOverlay);
   }
-  
-  if (loadSampleFile) {
+
+  if (randomizeBtn) {
+    randomizeBtn.addEventListener('click', randomizePattern);
+  }
+
+  if (clearBtn) {
+    clearBtn.addEventListener('click', clearPattern);
+  }
+
+  if (loadSampleBtn && loadSampleFile) {
+    loadSampleBtn.addEventListener('click', () => loadSampleFile.click());
     loadSampleFile.addEventListener('change', handleSampleLoad);
   }
-  
-  // Keyboard events
+
+  if (superRandomToggle) {
+    superRandomToggle.addEventListener('click', () => {
+      if (superRandomizerState.running) {
+        stopSuperRandomizer();
+      } else {
+        startSuperRandomizer();
+      }
+    });
+  }
+
+  if (superRandomIntervalSlider) {
+    const sliderValue = parseFloat(superRandomIntervalSlider.value);
+    if (isFinite(sliderValue)) {
+      superRandomizerState.baseInterval = sliderValue;
+    }
+    superRandomIntervalSlider.addEventListener('input', (event) => {
+      const value = parseFloat(event.target.value);
+      if (!isFinite(value)) return;
+      superRandomizerState.baseInterval = value;
+      updateSuperRandomizerIntervalDisplay();
+    });
+    superRandomIntervalSlider.addEventListener('change', () => {
+      if (superRandomizerState.running) {
+        scheduleNextSuperRandomizer();
+      }
+    });
+  }
+
+  superRandomOptions.forEach((input) => {
+    const feature = input.dataset.feature;
+    if (!feature) return;
+    if (Object.prototype.hasOwnProperty.call(superRandomizerState.toggles, feature)) {
+      input.checked = Boolean(superRandomizerState.toggles[feature]);
+    }
+    input.addEventListener('change', () => {
+      superRandomizerState.toggles[feature] = input.checked;
+      if (feature === 'interval' && superRandomizerState.running) {
+        scheduleNextSuperRandomizer();
+      }
+    });
+  });
+
   document.addEventListener('keydown', handleKeyDown);
   document.addEventListener('keyup', handleKeyUp);
-  
-  // Preset events
-  const presetsEl = document.getElementById('presets');
-  if (presetsEl) {
-    presetsEl.addEventListener('click', handlePresetClick);
-  }
+
+  initializeSuperRandomizerUi();
 }
 
-// Handle keyboard events
-function handleKeyDown(e) {
-  if (e.repeat) return;
-  
-  const track = state.tracks.find(t => t.key === e.key.toUpperCase());
+function handleKeyDown(event) {
+  if (event.repeat) return;
+  const key = event.key?.toUpperCase();
+  const track = state.tracks.find((t) => t.key === key);
   if (!track) return;
-  
-  const pad = document.querySelector(`[data-track="${track.id}"]`);
-  if (pad) {
-    pad.classList.add('active');
-    playPad(track.id);
-  }
+  const idx = state.tracks.indexOf(track);
+  const pad = document.querySelector(`.pad[data-track="${idx}"]`);
+  if (pad) pad.classList.add('active');
+  playPad(idx);
 }
 
-function handleKeyUp(e) {
-  const track = state.tracks.find(t => t.key === e.key.toUpperCase());
+function handleKeyUp(event) {
+  const key = event.key?.toUpperCase();
+  const track = state.tracks.find((t) => t.key === key);
   if (!track) return;
-  
-  const pad = document.querySelector(`[data-track="${track.id}"]`);
-  if (pad) {
-    pad.classList.remove('active');
+  const idx = state.tracks.indexOf(track);
+  const pad = document.querySelector(`.pad[data-track="${idx}"]`);
+  if (pad) pad.classList.remove('active');
+}
+
+function renderSoundboard() {
+  const container = document.getElementById('soundboard');
+  if (!container) return;
+  container.innerHTML = '';
+
+  state.soundboard.forEach((fx) => {
+    const btn = document.createElement('button');
+    btn.dataset.fx = fx.id;
+    btn.innerHTML = `<strong>${fx.label}</strong><span>${fx.description}</span>`;
+    if (fx.color) {
+      btn.style.borderColor = `${fx.color}40`;
+      btn.style.boxShadow = `0 0 0 1px ${fx.color}22`;
+    }
+    btn.addEventListener('click', async () => {
+      await engine.resume();
+      triggerSoundboardFx(fx.id);
+    });
+    container.appendChild(btn);
+  });
+}
+
+function renderInstrumentOverlay() {
+  const grid = document.getElementById('instrumentGrid');
+  if (!grid) return;
+  grid.innerHTML = '';
+
+  trackLibrary.forEach((template) => {
+    const card = document.createElement('div');
+    card.className = 'instrument-card';
+    card.dataset.template = template.id;
+    card.style.borderColor = (template.color || '#ffffff10');
+    card.innerHTML = `
+      <span class="badge">${template.category || template.type}</span>
+      <h3>${template.name}</h3>
+      <p>${getInstrumentDescription(template)}</p>
+    `;
+    card.addEventListener('click', () => {
+      addTrack(template.id);
+      closeInstrumentOverlay();
+    });
+    grid.appendChild(card);
+  });
+}
+
+function getInstrumentDescription(template) {
+  switch (template.type) {
+    case 'melody':
+      return 'Expressive melodic lane for chip leads and motifs.';
+    case 'arpeggio':
+      return 'Automatic arpeggiator that follows the active scale.';
+    case 'drum':
+      return 'Percussion voice crafted for retro punch and rhythm.';
+    case 'sample':
+      return 'Drop in custom textures or vocal chops.';
+    default:
+      return 'Add a new voice to your arrangement.';
   }
 }
 
-// Handle sample loading
-async function handleSampleLoad(e) {
-  const file = e.target.files[0];
+function openInstrumentOverlay() {
+  const overlay = document.getElementById('instrumentOverlay');
+  if (overlay) overlay.classList.add('open');
+}
+
+function closeInstrumentOverlay() {
+  const overlay = document.getElementById('instrumentOverlay');
+  if (overlay) overlay.classList.remove('open');
+}
+
+function addTrack(templateId) {
+  const track = instantiateTrack(templateId);
+  if (!track) return;
+  state.tracks.push(track);
+  state.selectedTrackIndex = state.tracks.length - 1;
+  buildTracks();
+  buildPads();
+  updateDisplay();
+}
+
+function removeTrack(index) {
+  if (index < 0 || index >= state.tracks.length) return;
+  state.tracks.splice(index, 1);
+  if (state.selectedTrackIndex >= state.tracks.length) {
+    state.selectedTrackIndex = state.tracks.length - 1;
+  }
+  buildTracks();
+  buildPads();
+  updateDisplay();
+}
+
+function selectTrack(index) {
+  if (index < 0 || index >= state.tracks.length) return;
+  state.selectedTrackIndex = index;
+  highlightSelectedTrack();
+}
+
+function highlightSelectedTrack() {
+  const tracks = document.querySelectorAll('.track');
+  tracks.forEach((trackEl, idx) => {
+    trackEl.classList.toggle('selected', idx === state.selectedTrackIndex);
+  });
+}
+
+function refreshScalePreview() {
+  const preview = document.getElementById('scalePreview');
+  if (!preview) return;
+  preview.innerHTML = '';
+  const notes = state.scale.notes || [];
+  notes.forEach((note) => {
+    const span = document.createElement('span');
+    span.textContent = note.label;
+    preview.appendChild(span);
+  });
+}
+
+function updateScaleSummary() {
+  const summary = document.getElementById('scaleSummary');
+  if (!summary) return;
+  const modeName = state.scale.mode.replace(/^(.)/, (m) => m.toUpperCase());
+  summary.textContent = `${state.scale.root} ${modeName}`;
+}
+
+function randomizeScale() {
+  const rootSelect = document.getElementById('scaleRoot');
+  const modeSelect = document.getElementById('scaleMode');
+  if (!rootSelect || !modeSelect) return;
+
+  const rootOptions = Array.from(rootSelect.options || []);
+  const modeOptions = Array.from(modeSelect.options || []);
+  if (!rootOptions.length || !modeOptions.length) return;
+
+  const randomRootOption = rootOptions[Math.floor(Math.random() * rootOptions.length)];
+  const randomModeOption = modeOptions[Math.floor(Math.random() * modeOptions.length)];
+
+  const nextRoot = randomRootOption?.value || randomRootOption?.text || state.scale.root;
+  const nextMode = randomModeOption?.value || randomModeOption?.text || state.scale.mode;
+
+  rootSelect.value = nextRoot;
+  modeSelect.value = nextMode;
+
+  updateScale(nextRoot, nextMode);
+  refreshScalePreview();
+  updateScaleSummary();
+  rebuildGrids();
+}
+
+function adjustTrackRegister(index, delta) {
+  const track = state.tracks[index];
+  if (!track) return;
+  const notes = state.scale.notes || [];
+  const span = Math.max(1, track.noteSpan || notes.length);
+  const maxOffset = Math.max(0, notes.length - span);
+  const next = clamp((track.noteOffset || 0) + delta, 0, maxOffset);
+  track.noteOffset = next;
+  clampTrackToScale(track);
+  updateTrackGrid(index);
+  buildPads();
+}
+
+function randomizePattern() {
+  state.tracks.forEach((track, idx) => {
+    if (track.type === 'drum' || track.type === 'sample') {
+      const density = track.drumType === 'hat' ? 0.45 : track.drumType === 'kick' ? 0.3 : 0.25;
+      track.steps = track.steps.map(() => {
+        if (Math.random() < density) {
+          return 1 + Math.floor(Math.random() * 3);
+        }
+        return 0;
+      });
+    } else {
+      const slice = getTrackScale(track);
+      track.steps = track.steps.map(() => {
+        if (!slice.length || Math.random() < 0.65) return null;
+        const noteIndex = Math.floor(Math.random() * slice.length);
+        const velocity = 1 + Math.floor(Math.random() * 3);
+        return { noteIndex, velocity };
+      });
+    }
+    updateTrackGrid(idx);
+  });
+}
+
+function clearPattern() {
+  state.tracks.forEach((track, idx) => {
+    if (track.type === 'drum' || track.type === 'sample') {
+      track.steps = new Array(state.steps).fill(0);
+    } else {
+      track.steps = new Array(state.steps).fill(null);
+    }
+    updateTrackGrid(idx);
+  });
+}
+
+function initializeSuperRandomizerUi() {
+  updateSuperRandomizerButton();
+  updateSuperRandomizerIntervalDisplay();
+  updateSuperRandomizerCountdown();
+}
+
+function updateSuperRandomizerButton() {
+  const btn = document.getElementById('superRandomToggle');
+  if (btn) {
+    btn.textContent = superRandomizerState.running ? 'Stop Chaos' : 'Start Chaos';
+    btn.setAttribute('aria-pressed', superRandomizerState.running ? 'true' : 'false');
+    btn.classList.toggle('danger', superRandomizerState.running);
+    btn.classList.toggle('primary', !superRandomizerState.running);
+  }
+  const container = document.getElementById('superRandomizer');
+  if (container) {
+    container.classList.toggle('running', superRandomizerState.running);
+  }
+}
+
+function updateSuperRandomizerIntervalDisplay() {
+  const slider = document.getElementById('superRandomInterval');
+  const label = document.getElementById('superRandomIntervalVal');
+  if (slider) {
+    const min = parseFloat(slider.min) || 2;
+    const max = parseFloat(slider.max) || 20;
+    const value = clamp(superRandomizerState.baseInterval || min, min, max);
+    superRandomizerState.baseInterval = value;
+    slider.value = String(Math.round(value));
+    if (label) label.textContent = `${Math.round(value)}s`;
+  } else if (label) {
+    label.textContent = `${Math.round(superRandomizerState.baseInterval)}s`;
+  }
+}
+
+function updateSuperRandomizerCountdown() {
+  const countdown = document.getElementById('superRandomCountdown');
+  if (!countdown) return;
+  if (!superRandomizerState.running || !superRandomizerState.nextTriggerTime) {
+    countdown.textContent = '--';
+    return;
+  }
+  const remaining = superRandomizerState.nextTriggerTime - Date.now();
+  const seconds = Math.max(0, remaining / 1000);
+  countdown.textContent = `${seconds.toFixed(1)}s`;
+}
+
+function startSuperRandomizer() {
+  if (superRandomizerState.running) return;
+  superRandomizerState.running = true;
+  updateSuperRandomizerButton();
+  performSuperRandomizer();
+  scheduleNextSuperRandomizer();
+  if (superRandomizerState.countdownId) {
+    clearInterval(superRandomizerState.countdownId);
+  }
+  superRandomizerState.countdownId = setInterval(updateSuperRandomizerCountdown, 100);
+  updateSuperRandomizerCountdown();
+}
+
+function stopSuperRandomizer() {
+  if (!superRandomizerState.running) return;
+  superRandomizerState.running = false;
+  if (superRandomizerState.timerId) {
+    clearTimeout(superRandomizerState.timerId);
+    superRandomizerState.timerId = null;
+  }
+  if (superRandomizerState.countdownId) {
+    clearInterval(superRandomizerState.countdownId);
+    superRandomizerState.countdownId = null;
+  }
+  superRandomizerState.nextTriggerTime = 0;
+  updateSuperRandomizerButton();
+  updateSuperRandomizerCountdown();
+}
+
+function scheduleNextSuperRandomizer() {
+  if (superRandomizerState.timerId) {
+    clearTimeout(superRandomizerState.timerId);
+    superRandomizerState.timerId = null;
+  }
+  if (!superRandomizerState.running) {
+    superRandomizerState.nextTriggerTime = 0;
+    updateSuperRandomizerCountdown();
+    return;
+  }
+  const intervalSeconds = computeSuperRandomizerInterval();
+  superRandomizerState.nextTriggerTime = Date.now() + intervalSeconds * 1000;
+  superRandomizerState.timerId = setTimeout(() => {
+    if (!superRandomizerState.running) return;
+    performSuperRandomizer();
+    scheduleNextSuperRandomizer();
+  }, intervalSeconds * 1000);
+  updateSuperRandomizerCountdown();
+}
+
+function computeSuperRandomizerInterval() {
+  const slider = document.getElementById('superRandomInterval');
+  const sliderMin = slider ? parseFloat(slider.min) || 2 : 2;
+  const sliderMax = slider ? parseFloat(slider.max) || 20 : 20;
+  const base = clamp(superRandomizerState.baseInterval || sliderMin, sliderMin, sliderMax);
+  superRandomizerState.baseInterval = base;
+  if (!superRandomizerState.toggles.interval) {
+    return base;
+  }
+  const lower = clamp(base * 0.5, sliderMin, sliderMax);
+  const upper = clamp(base * 1.5, sliderMin, sliderMax);
+  const min = Math.min(lower, upper);
+  const max = Math.max(lower, upper);
+  if (max <= min) return min;
+  return min + Math.random() * (max - min);
+}
+
+function performSuperRandomizer() {
+  const toggles = superRandomizerState.toggles;
+  let tracksChanged = false;
+
+  if (toggles.tracks) {
+    tracksChanged = randomizeTrackCount() || tracksChanged;
+  }
+
+  if (toggles.instruments) {
+    tracksChanged = randomizeTrackInstruments() || tracksChanged;
+  }
+
+  if (toggles.key) {
+    randomizeScale();
+  }
+
+  if (toggles.tempo) {
+    randomizeTempo();
+  }
+
+  if (tracksChanged) {
+    buildTracks();
+    buildPads();
+  }
+
+  updateDisplay();
+}
+
+function randomizeTrackCount() {
+  const maxTracks = Math.min(KEY_POOL.length, trackLibrary.length);
+  if (maxTracks <= 0) return false;
+  const minTracks = Math.min(4, maxTracks);
+  const target = Math.floor(Math.random() * (maxTracks - minTracks + 1)) + minTracks;
+  const current = state.tracks.length;
+  if (target === current) return false;
+
+  if (target > current) {
+    const existingIds = new Set(state.tracks.map((track) => track.templateId));
+    const unusedTemplates = shuffleArray(trackLibrary.filter((template) => !existingIds.has(template.id)));
+    while (state.tracks.length < target && unusedTemplates.length) {
+      const template = unusedTemplates.shift();
+      const track = instantiateTrack(template.id);
+      if (track) state.tracks.push(track);
+    }
+    while (state.tracks.length < target) {
+      const template = trackLibrary[Math.floor(Math.random() * trackLibrary.length)];
+      const track = instantiateTrack(template.id);
+      if (track) state.tracks.push(track);
+    }
+  } else {
+    while (state.tracks.length > target) {
+      const removeIndex = Math.floor(Math.random() * state.tracks.length);
+      state.tracks.splice(removeIndex, 1);
+    }
+    if (state.tracks.length) {
+      state.selectedTrackIndex = clamp(state.selectedTrackIndex, 0, state.tracks.length - 1);
+    } else {
+      state.selectedTrackIndex = 0;
+    }
+  }
+
+  return true;
+}
+
+function randomizeTrackInstruments() {
+  if (!state.tracks.length) return false;
+  const shuffledTemplates = shuffleArray(trackLibrary);
+  let pointer = 0;
+  const nextTracks = state.tracks.map((track) => {
+    if (pointer >= shuffledTemplates.length) {
+      pointer = 0;
+    }
+    const template = shuffledTemplates[pointer++];
+    const next = instantiateTrack(template.id);
+    if (!next) return track;
+    next.key = track.key;
+    return next;
+  });
+  state.tracks = nextTracks;
+  if (state.tracks.length) {
+    state.selectedTrackIndex = clamp(state.selectedTrackIndex, 0, state.tracks.length - 1);
+  } else {
+    state.selectedTrackIndex = 0;
+  }
+  return true;
+}
+
+function randomizeTempo() {
+  const slider = document.getElementById('bpm');
+  const min = slider ? parseInt(slider.min, 10) || 40 : 40;
+  const max = slider ? parseInt(slider.max, 10) || 220 : 220;
+  const next = Math.floor(Math.random() * (max - min + 1)) + min;
+  state.bpm = next;
+  if (slider) slider.value = String(next);
+}
+
+function shuffleArray(array) {
+  const copy = array.slice();
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+async function handleSampleLoad(event) {
+  const file = event.target.files?.[0];
+  event.target.value = '';
   if (!file) return;
-  
+
   try {
     const arrayBuffer = await file.arrayBuffer();
     const buffer = await engine.decodeSample(arrayBuffer);
-    
-    if (buffer) {
-      // Find first sample track or create one
-      let sampleTrack = state.tracks.find(t => t.type === 'sample');
-      if (!sampleTrack) {
-        sampleTrack = state.tracks[0];
-        sampleTrack.type = 'sample';
+    if (!buffer) return;
+
+    let targetIndex = state.selectedTrackIndex;
+    let track = state.tracks[targetIndex];
+    if (!track || track.type !== 'sample') {
+      track = state.tracks.find((t) => t.type === 'sample');
+      if (!track) {
+        const newTrack = instantiateTrack('samplePad');
+        if (newTrack) {
+          newTrack.sample = buffer;
+          newTrack.name = file.name.replace(/\.[^/.]+$/, '');
+          state.tracks.push(newTrack);
+          state.selectedTrackIndex = state.tracks.length - 1;
+          buildTracks();
+          buildPads();
+          return;
+        }
+        return;
       }
-      
-      sampleTrack.sample = buffer;
-      sampleTrack.name = file.name.replace(/\.[^/.]+$/, '');
-      
-      // Update UI
-      const trackEl = document.querySelector(`[data-track="${sampleTrack.id}"]`);
-      if (trackEl) {
-        const select = trackEl.querySelector('.track-select');
-        if (select) select.value = 'sample';
-      }
-      
-      console.log('Sample loaded:', file.name);
+      targetIndex = state.tracks.indexOf(track);
     }
-  } catch (error) {
-    console.error('Failed to load sample:', error);
+
+    track.sample = buffer;
+    track.name = file.name.replace(/\.[^/.]+$/, '');
+    state.selectedTrackIndex = targetIndex;
+    buildTracks();
+    buildPads();
+  } catch (err) {
+    console.warn('Failed to load sample', err);
   }
 }
 
-// Handle preset clicks
-function handlePresetClick(e) {
-  const chip = e.target.closest('.preset-chip');
-  if (!chip) return;
-  
-  document.querySelectorAll('.preset-chip').forEach(c => c.classList.remove('active'));
-  chip.classList.add('active');
-  
-  const preset = chip.dataset.preset;
-  if (preset === 'chiptune') loadChiptune();
-  else if (preset === 'electro') loadElectro();
-  else if (preset === 'random') randomize();
-  else if (preset === 'clear') clearAll();
-  else if (chip.dataset.idx) {
-    const idx = parseInt(chip.dataset.idx);
-    if (isFinite(idx)) loadPresetByIndex(idx);
-  }
-}
-
-// Render preset bank
-function renderPresetBank() {
-  const container = document.getElementById('presets');
-  if (!container) return;
-  
-  const frag = document.createDocumentFragment();
-  PRESET_BANK.forEach((p, i) => {
-    const btn = document.createElement('button');
-    btn.className = 'preset-chip';
-    btn.textContent = p.name;
-    btn.dataset.idx = String(i);
-    frag.appendChild(btn);
-  });
-  container.appendChild(frag);
-}
-
-// Preset loading functions
-function parseRow(s) {
-  const res = new Array(16).fill(0);
-  if (!s) return res;
-  for (let i = 0; i < Math.min(16, s.length); i++) {
-    const c = s[i];
-    res[i] = c === 'x' ? 1 : c === 'X' ? 2 : c === '!' ? 3 : 0;
-  }
-  return res;
-}
-
-function applyPatternRows(rows) {
-  state.steps = 16;
-  const stepsSelect = document.getElementById('steps');
-  if (stepsSelect) stepsSelect.value = '16';
-  
-  rebuildGrids();
-  clearAll();
-  
-  const trackOrder = [0, 1, 2, 3, 4, 5, 6, 7];
-  for (let ti = 0; ti < trackOrder.length; ti++) {
-    const row = rows[ti] || ''.padEnd(16, '.');
-    const levels = Array.isArray(row) ? row : parseRow(row);
-    for (let i = 0; i < 16; i++) {
-      const lvl = levels[i] | 0;
-      if (lvl > 0) setCell(trackOrder[ti], i, lvl);
-    }
-  }
-}
-
-function loadPresetByIndex(i) {
-  const p = PRESET_BANK[i | 0];
-  if (!p) return;
-  applyPatternRows(p.rows);
-}
-
-// Preset patterns
-const PRESET_BANK = [
-  { name: '808 Classic', rows: [
-    '!...!...!...!...', // Kick
-    '....X.......X...', // Snare
-    '................', // Clap
-    'x.x.x.x.x.x.x.x.', // CHat
-    '........X.......', // OHat
-    '...........x....', // Tom
-    '................', // Cow
-    '................'  // Sample
-  ]},
-  { name: 'Boom Bap', rows: [
-    '!.....!..!..!...',
-    '....X.......X...',
-    '........X.......',
-    'x.x.x.x.x.x.x.x.',
-    '........X.......',
-    '......x.........',
-    '........x.......',
-    '................'
-  ]},
-  { name: 'Electro Funk', rows: [
-    '!....!..!..!..!..',
-    '....X.......X....',
-    '....x.......x....',
-    'x.x.x.x.x.x.x.x.',
-    '........X.......',
-    '......x.....x...',
-    '........x.......',
-    '................'
-  ]},
-  { name: 'Techno 4x4', rows: [
-    '!...!...!...!...',
-    '........X.......',
-    '................',
-    'x.x.x.x.x.x.x.x.',
-    '........X.......',
-    '................',
-    '................',
-    '................'
-  ]},
-  { name: 'House Jack', rows: [
-    '!...!...!...!...',
-    '........X.......',
-    '....x.......x...',
-    'x.x.x.x.x.x.x.x.',
-    '........X.......',
-    '..........x.....',
-    '................',
-    '................'
-  ]},
-  { name: 'Trap Basic', rows: [
-    '!.....!..!..!...',
-    '....X.......X...',
-    '..x.....x.......',
-    'x.xxx.x.x.xxx.x.',
-    '...........X....',
-    '........x.......',
-    '............x...',
-    '................'
-  ]},
-  { name: 'Trap Triplet', rows: [
-    '!....!..!..!..!..',
-    '....X.......X....',
-    '...x..x..x..x....',
-    'x.xxx.xxx.xxx.x..',
-    '..........X......',
-    '........x.......',
-    '...........x....',
-    '................'
-  ]},
-  { name: 'DnB Roller', rows: [
-    '!.....!..!..!...',
-    '....X...X....X..',
-    '........x.......',
-    'x.xxxxxxxxxxxx.x',
-    '......X.........',
-    '......x.........',
-    '................',
-    '................'
-  ]},
-  { name: 'UKG Shuffle', rows: [
-    '!...!..!..!..!..',
-    '......X.....X...',
-    '....x.......x...',
-    'x.x.x.x.x.x.x.x.',
-    '......X.........',
-    '..........x.....',
-    '........x.......',
-    '................'
-  ]},
-  { name: 'Boom Trap', rows: [
-    '!.....!..!..!...',
-    '....X.....X.....',
-    '....x...........',
-    'x.xx.x.xx.x.xx..',
-    '...........X....',
-    '........x.......',
-    '............x...',
-    '................'
-  ]},
-  { name: 'Electro Clack', rows: [
-    '!....!..!..!..!..',
-    '....X.......X....',
-    '....X.......X....',
-    'x.x.x.x.x.x.x.x.',
-    '........X.......',
-    '......x.....x...',
-    '........x.......',
-    '................'
-  ]},
-  { name: 'Minimal', rows: [
-    '!...............',
-    '........X.......',
-    '................',
-    'x...x...x...x...',
-    '........X.......',
-    '................',
-    '................',
-    '................'
-  ]},
-  { name: 'Half-time', rows: [
-    '!.....!.....!...',
-    '........X.......',
-    '....x.......x...',
-    'x.x.x.x.x.x.x.x.',
-    '..........X......',
-    '......x.........',
-    '................',
-    '................'
-  ]},
-  { name: 'Garage Skips', rows: [
-    '!...!..!..!..!..',
-    '......X.....X...',
-    '....x..x........',
-    'x.x..x.x.x..x.x.',
-    '......X.........',
-    '..........x.....',
-    '........x.......',
-    '................'
-  ]},
-  { name: 'Afro 1', rows: [
-    '!..!..!..!..!..!',
-    '......X.....X...',
-    '....x...x.......',
-    'x..x.x..x.x..x..',
-    '........X.......',
-    '......x.........',
-    '........x.......',
-    '................'
-  ]},
-  { name: 'Afro 2', rows: [
-    '!..!..!..!..!..!',
-    '......X.....X...',
-    '........x.......',
-    'x.x..x..x.x..x..',
-    '........X.......',
-    '......x..x......',
-    '........x.......',
-    '................'
-  ]},
-  { name: 'Reggaeton', rows: [
-    '!..!..!..!..!...',
-    '......X.....X...',
-    '....X.......X...',
-    'x...x.x...x.x...',
-    '........X.......',
-    '..........x.....',
-    '........x.......',
-    '................'
-  ]},
-  { name: 'Latin House', rows: [
-    '!...!....!..!...',
-    '......X.....X...',
-    '....x.......x...',
-    'x.x.x.x.x.x.x.x.',
-    '........X.......',
-    '......x.....x...',
-    '........x.......',
-    '................'
-  ]},
-  { name: 'Footwork', rows: [
-    '!....!..!..!..!..',
-    '....X.X.....X....',
-    '....x.......x....',
-    'x.xxx.xxx.xxx.x..',
-    '..........X......',
-    '........x.......',
-    '...........x....',
-    '................'
-  ]},
-  { name: 'R&B Slow', rows: [
-    '!.......!.......',
-    '.......X........',
-    '........x.......',
-    'x..x..x..x..x..x',
-    '........X.......',
-    '......x.........',
-    '................',
-    '................'
-  ]},
-  { name: 'Funk Break', rows: [
-    '!.....!..!..!...',
-    '....X...X....X..',
-    '........x.......',
-    'x.x.x.xx.x.x.xx.',
-    '......X.........',
-    '......x.........',
-    '................',
-    '................'
-  ]},
-  { name: 'New Jack', rows: [
-    '!...!..!..!..!..',
-    '....X.......X....',
-    '....X.......X....',
-    'x.x.x.x.x.x.x.x.',
-    '........X.......',
-    '......x.....x...',
-    '........x.......',
-    '................'
-  ]},
-  { name: 'Electro Pop', rows: [
-    '!...!....!..!...',
-    '......X.....X...',
-    '....x.......x...',
-    'x.x.x.x.x.x.x.x.',
-    '........X.......',
-    '..........x.....',
-    '........x.......',
-    '................'
-  ]},
-  { name: 'Tech House', rows: [
-    '!...!...!...!...',
-    '........X.......',
-    '................',
-    'x.x.x.x.x.x.x.x.',
-    '........X.......',
-    '............x...',
-    '................',
-    '................'
-  ]},
-  { name: 'LoFi Hop', rows: [
-    '!.....!..!..!...',
-    '....X.......X...',
-    '........x.......',
-    'x..x..x..x..x..x',
-    '........X.......',
-    '......x.........',
-    '................',
-    '................'
-  ]},
-  { name: 'Industrial', rows: [
-    '!X..!X..!X..!X..',
-    '....X.......X...',
-    '..X.....X.......',
-    'x.xXx.xXx.xXx.xX',
-    '........X.......',
-    '....x....x......',
-    '........x.......',
-    '................'
-  ]},
-  { name: 'Chillwave', rows: [
-    '!...!....!...!..',
-    '........X.......',
-    '....x.......x...',
-    'x...x...x...x...',
-    '..........X......',
-    '......x.........',
-    '................',
-    '................'
-  ]}
-];
-
-// Preset loading functions
-function loadChiptune() {
-  applyPatternRows([
-    '!...!...!...!...',
-    '....X.......X...',
-    '................',
-    'x.x.x.x.x.x.x.x.',
-    '........X.......',
-    '................',
-    '................',
-    '................'
-  ]);
-}
-
-function loadElectro() {
-  applyPatternRows([
-    '!...!...!...!...',
-    '........X.......',
-    '................',
-    'x.x.x.x.x.x.x.x.',
-    '........X.......',
-    '................',
-    '................',
-    '................'
-  ]);
-}
-
-function randomize() {
-  for (const track of state.tracks) {
-    const density = track.type === "hat" ? 0.32 : (track.type === 'kick' ? 0.2 : 0.24);
-    for (let i = 0; i < state.steps; i++) {
-      const on = Math.random() < density ? (1 + Math.floor(Math.random() * 3)) : 0;
-      setCell(track.id, i, on);
-    }
-  }
-}
-
-function clearAll() {
-  state.tracks.forEach(track => {
-    track.steps.fill(0);
-    updateTrackGrid(track.id);
-  });
-}
-
-// Export functions
-window.buildUI = buildUI;
+window.buildInterface = buildInterface;
 window.buildTracks = buildTracks;
 window.buildPads = buildPads;
 window.rebuildGrids = rebuildGrids;
 window.updateTrackGrid = updateTrackGrid;
-window.cycleCell = cycleCell;
-window.decreaseCell = decreaseCell;
-window.setCell = setCell;
 window.updateDisplay = updateDisplay;
 window.setupEventListeners = setupEventListeners;
-window.handleKeyDown = handleKeyDown;
-window.handleKeyUp = handleKeyUp;
 window.handleSampleLoad = handleSampleLoad;
-window.handlePresetClick = handlePresetClick;
-window.renderPresetBank = renderPresetBank;
-window.loadChiptune = loadChiptune;
-window.loadElectro = loadElectro;
-window.randomize = randomize;
-window.clearAll = clearAll;
-window.loadPresetByIndex = loadPresetByIndex;
-window.PRESET_BANK = PRESET_BANK;
+window.refreshScalePreview = refreshScalePreview;
+window.updateScaleSummary = updateScaleSummary;
+window.randomizeScale = randomizeScale;
+window.randomizePattern = randomizePattern;
+window.clearPattern = clearPattern;


### PR DESCRIPTION
## Summary
- add a Super Randomizer control panel to the header with toggles for tracks, instruments, key, tempo and shuffle interval plus a chaos start/stop control
- wire the UI logic to cycle through randomized track counts, instrument swaps, scale changes, tempo shifts and timer intervals while updating the studio layout
- style the new top-bar panel and chip toggles to match the neon studio aesthetic

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceb05795888327a3d6c039c8f476ed